### PR TITLE
preventDefault on enter key press, fixes #113

### DIFF
--- a/src/js/forms/Forms.js
+++ b/src/js/forms/Forms.js
@@ -8,6 +8,7 @@ L.DNC.Forms = L.Class.extend({
     **
     ** RENDER FORM TEMPLATE
     **
+    ** TODO: write tests for Forms
     */
     render: function ( title, options ) {
 
@@ -96,6 +97,7 @@ L.DNC.Forms = L.Class.extend({
 
     },
 
+    // TODO: validate the form
     validateForm: function () {
         // do some validation eventually
         return true;
@@ -119,6 +121,7 @@ L.DNC.Forms = L.Class.extend({
             }
         });
 
+        // bind event handler to form submit button
         var submit = document.getElementById('operation-submit');
         submit.addEventListener('click', this.submitForm.bind(this));
     },

--- a/src/js/forms/Forms.js
+++ b/src/js/forms/Forms.js
@@ -20,7 +20,7 @@ L.DNC.Forms = L.Class.extend({
                 '<button type="button" class="btn close form-close"><i class="fa fa-times"></i></button>'+
                 '<div class="form-information"><h3 class="form-title">' + this.title + '</h3>'+
                 '<p class="form-description">' + this.options.description + '</p></div>'+
-                '<form class="form-inputs">';
+                '<form id="operation-form" class="form-inputs">';
 
         if ( this.options.parameters ) {
 
@@ -102,10 +102,22 @@ L.DNC.Forms = L.Class.extend({
     },
 
     _formHandlers: function() {
+
+        var _this = this;
+
         var closers = document.getElementsByClassName('form-close');
         for ( var x = 0; x < closers.length; x++ ) {
-          closers[x].addEventListener('click', this.closeForm.bind(this));
+            closers[x].addEventListener('click', this.closeForm.bind(this));
         }
+
+        // form submit checks for enter key to prevent default
+        var form = document.getElementById('operation-form');
+        form.addEventListener('keypress', function( event ){
+            if ( event.keyCode == 13 ) {
+                event.preventDefault();
+                _this.submitForm();
+            }
+        });
 
         var submit = document.getElementById('operation-submit');
         submit.addEventListener('click', this.submitForm.bind(this));


### PR DESCRIPTION
### What changed?

* adding a check when the user presses a key that equals the enter `keyCode` of `13`. If enter is pressed prevent the default response (of submitting the form via HTTP) and running our own `_this.submitForm()` function. #113 