### PR TITLE
Rename to dropchop

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
           sourceMap: true
         },
         files: {
-          'dist/js/dropchop.min.js': ['dist/js/vendor.js', 'dist/js/L.DNC.js']
+          'dist/js/dropchop.min.js': ['dist/js/bundle.js']
         }
       }
     },
@@ -80,7 +80,7 @@ module.exports = function(grunt) {
     concat: {
         dist: {
           src: ['src/js/*.js', 'src/js/menu/MenuBar.js', 'src/js/**/*.js'],
-          dest: 'dist/js/L.DNC.js'
+          dest: 'dist/js/L.Dropchop.js'
         },
     },
     karma: {
@@ -116,13 +116,7 @@ module.exports = function(grunt) {
       }
     },
     browserify: {
-      vendor: {
-        src: [],
-        dest: 'dist/js/vendor.js',
-        options: {
-          require: ['shp-write', 'turf']
-        }
-      }
+      'dist/js/bundle.js': ['dist/js/L.Dropchop.js']
     }
   });
 
@@ -144,7 +138,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['karma']);
   grunt.registerTask('lint', ['jshint']);
   // JS
-  grunt.registerTask('js:dev', ['browserify', 'jshint', 'concat', 'uglify', 'test']);
+  grunt.registerTask('js:dev', ['jshint', 'browserify', 'uglify', 'test']);
   grunt.registerTask('js:prod', ['browserify', 'concat', 'uglify']);
   // CSS
   grunt.registerTask('css:dev', ['sass']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,6 +77,12 @@ module.exports = function(grunt) {
         include: ['htmlprod', 'stylesheets', 'jsprod', 'tests']
       },
     },
+    concat: {
+        dist: {
+          src: ['src/js/*.js', 'src/js/menu/MenuBar.js', 'src/js/**/*.js'],
+          dest: 'dist/js/L.Dropchop.js'
+        },
+    },
     karma: {
       unit: {
           configFile: 'spec/karma.conf.js'
@@ -116,6 +122,7 @@ module.exports = function(grunt) {
 
   // Loading tasks.
   grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
@@ -131,8 +138,8 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['karma']);
   grunt.registerTask('lint', ['jshint']);
   // JS
-  grunt.registerTask('js:dev', ['jshint', 'browserify', 'uglify', 'test']);
-  grunt.registerTask('js:prod', ['browserify', 'uglify']);
+  grunt.registerTask('js:dev', ['jshint', 'concat', 'browserify', 'uglify', 'test']);
+  grunt.registerTask('js:prod', ['concat', 'browserify', 'uglify']);
   // CSS
   grunt.registerTask('css:dev', ['sass']);
   grunt.registerTask('css:prod', ['sass']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,12 +77,6 @@ module.exports = function(grunt) {
         include: ['htmlprod', 'stylesheets', 'jsprod', 'tests']
       },
     },
-    concat: {
-        dist: {
-          src: ['src/js/*.js', 'src/js/menu/MenuBar.js', 'src/js/**/*.js'],
-          dest: 'dist/js/L.Dropchop.js'
-        },
-    },
     karma: {
       unit: {
           configFile: 'spec/karma.conf.js'
@@ -122,7 +116,6 @@ module.exports = function(grunt) {
 
   // Loading tasks.
   grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
@@ -139,7 +132,7 @@ module.exports = function(grunt) {
   grunt.registerTask('lint', ['jshint']);
   // JS
   grunt.registerTask('js:dev', ['jshint', 'browserify', 'uglify', 'test']);
-  grunt.registerTask('js:prod', ['browserify', 'concat', 'uglify']);
+  grunt.registerTask('js:prod', ['browserify', 'uglify']);
   // CSS
   grunt.registerTask('css:dev', ['sass']);
   grunt.registerTask('css:prod', ['sass']);

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "DropnChop",
+  "name": "Dropchop",
   "version": "0.0.1",
   "description": "GIS in the browser.",
-  "homepage": "https://github.com/cugos/drop-n-chop",
-  "bugs": "https://github.com/cugos/drop-n-chop",
+  "homepage": "https://github.com/cugos/dropchop",
+  "bugs": "https://github.com/cugos/dropchop",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cugos/drop-n-chop"
+    "url": "https://github.com/cugos/dropchop"
   },
   "main": "src/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "grunt-browserify": "^3.8.0",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "0.5.x",
-    "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-copy": "0.4.x",
     "grunt-contrib-jshint": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "grunt-browserify": "^3.8.0",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "0.5.x",
+    "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-copy": "0.4.x",
     "grunt-contrib-jshint": "0.7.0",

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function (config) {
         files: [
             "node_modules/mapbox.js/src/index.js",
             "node_modules/turf/turf.js",
-            "dist/js/L.DNC.js",
+            "dist/js/dropchop.min.js",
             "spec/**/*.js",
         ],
         exclude: [],

--- a/spec/suites/L.Dropchop.DropZone.FileReader.js
+++ b/spec/suites/L.Dropchop.DropZone.FileReader.js
@@ -1,4 +1,4 @@
-describe("L.DNC.DropZone.FileReader", function () {
+describe("L.Dropchop.DropZone.FileReader", function () {
     var map;
 
 
@@ -14,7 +14,7 @@ describe("L.DNC.DropZone.FileReader", function () {
         beforeEach(function () {
             _console.debug = console.debug;
             console.debug = function(){};
-            fileReader = new L.DNC.DropZone.FileReader( map, fakeOptions );
+            fileReader = new L.Dropchop.DropZone.FileReader( map, fakeOptions );
         });
 
         afterEach(function(){
@@ -22,7 +22,7 @@ describe("L.DNC.DropZone.FileReader", function () {
         });
 
         it("fileReader instance is activated correctly", function () {
-            expect(fileReader instanceof L.DNC.DropZone.FileReader).to.equal(true);
+            expect(fileReader instanceof L.Dropchop.DropZone.FileReader).to.equal(true);
         });
 
         it("fileReader instance has passed options", function () {
@@ -41,7 +41,7 @@ describe("L.DNC.DropZone.FileReader", function () {
         map_filereader_enabled_dispatched = false;
 
         beforeEach(function () {
-            fileReader = new L.DNC.DropZone.FileReader( map, {} );
+            fileReader = new L.Dropchop.DropZone.FileReader( map, {} );
 
             fileReader.on( "enabled", function(e){
                 filereader_enabled_dispatched = true;
@@ -78,7 +78,7 @@ describe("L.DNC.DropZone.FileReader", function () {
         map_filereader_disabled_dispatched = false;
 
         beforeEach(function () {
-            fileReader = new L.DNC.DropZone.FileReader( map, {} );
+            fileReader = new L.Dropchop.DropZone.FileReader( map, {} );
 
             fileReader.on( "disabled", function(e){
                 filereader_disabled_dispatched = true;
@@ -116,7 +116,7 @@ describe("L.DNC.DropZone.FileReader", function () {
         var mockDomEvent = null;
 
         beforeEach(function () {
-            fileReader = new L.DNC.DropZone.FileReader( map, {} );
+            fileReader = new L.Dropchop.DropZone.FileReader( map, {} );
             fileReader._map = null; // determines that listeners are never created
 
             mockDomEvent = sinon.mock(L.DomEvent);
@@ -142,7 +142,7 @@ describe("L.DNC.DropZone.FileReader", function () {
         var mockDomEvent = null;
 
         beforeEach(function () {
-            fileReader = new L.DNC.DropZone.FileReader( map, {} );
+            fileReader = new L.Dropchop.DropZone.FileReader( map, {} );
 
             mockDomEvent = sinon.mock(L.DomEvent);
             mockDomEvent.expects("on").atLeast(3);
@@ -167,7 +167,7 @@ describe("L.DNC.DropZone.FileReader", function () {
         var mockDomEvent = null;
 
         beforeEach(function () {
-            fileReader = new L.DNC.DropZone.FileReader( map, {} );
+            fileReader = new L.Dropchop.DropZone.FileReader( map, {} );
             fileReader._map = null; // determines that listeners are never created
 
             mockDomEvent = sinon.mock(L.DomEvent);
@@ -193,7 +193,7 @@ describe("L.DNC.DropZone.FileReader", function () {
         var mockDomEvent = null;
 
         beforeEach(function () {
-            fileReader = new L.DNC.DropZone.FileReader( map, {} );
+            fileReader = new L.Dropchop.DropZone.FileReader( map, {} );
 
             mockDomEvent = sinon.mock(L.DomEvent);
             mockDomEvent.expects("off").atLeast(3);

--- a/spec/suites/L.Dropchop.DropZone.js
+++ b/spec/suites/L.Dropchop.DropZone.js
@@ -1,4 +1,4 @@
-describe("L.DNC.DropZone", function () {
+describe("L.Dropchop.DropZone", function () {
     var map;
 
     beforeEach(function () {
@@ -10,11 +10,11 @@ describe("L.DNC.DropZone", function () {
         var dropzone = null;
 
         beforeEach(function () {
-            dropzone = new L.DNC.DropZone( map, fakeOptions );
+            dropzone = new L.Dropchop.DropZone( map, fakeOptions );
         });
 
         it("dropzone instance is activated correctly", function () {
-            expect(dropzone instanceof L.DNC.DropZone).to.equal(true);
+            expect(dropzone instanceof L.Dropchop.DropZone).to.equal(true);
         });
 
         it("dropzone instance options correctly set", function () {
@@ -22,7 +22,7 @@ describe("L.DNC.DropZone", function () {
         });
 
         it("dropzone instance has fileReader ref activated correctly", function () {
-            expect(dropzone.fileReader instanceof L.DNC.DropZone.FileReader).to.equal(true);
+            expect(dropzone.fileReader instanceof L.Dropchop.DropZone.FileReader).to.equal(true);
         });
     });
 

--- a/spec/suites/L.Dropchop.File.js
+++ b/spec/suites/L.Dropchop.File.js
@@ -1,4 +1,4 @@
-describe("L.DNC.FileExecute Operations", function(){
+describe("L.Dropchop.FileExecute Operations", function(){
 	var menu;
 	var ops;
 	var exampleData = true;

--- a/spec/suites/L.Dropchop.Forms.js
+++ b/spec/suites/L.Dropchop.Forms.js
@@ -1,4 +1,4 @@
-describe("L.DNC.Forms", function () {
+describe("L.Dropchop.Forms", function () {
     var expectedOptions = {
         options: {
             maxFeatures: 1,
@@ -29,9 +29,9 @@ describe("L.DNC.Forms", function () {
     
     // var expectedParameters = [Object, 10, "miles"];
 
-    var geo = new L.DNC.Geo();
+    var geo = new L.Dropchop.Geo();
     var buffer = geo.buffer;
-    var forms = new L.DNC.Forms();
+    var forms = new L.Dropchop.Forms();
 
     beforeEach(function () {
         form = forms.render('buffer', buffer);

--- a/spec/suites/L.Dropchop.Geo.js
+++ b/spec/suites/L.Dropchop.Geo.js
@@ -1,12 +1,12 @@
-describe("L.DNC.GeoExecute", function () {
+describe("L.Dropchop.GeoExecute", function () {
     var menu;
     var ops;
     var _console = {};
 
     beforeEach(function () {
         ops = {
-            geo: new L.DNC.Geo(),
-            geox: new L.DNC.GeoExecute()
+            geo: new L.Dropchop.Geo(),
+            geox: new L.Dropchop.GeoExecute()
         };
 
 

--- a/spec/suites/L.Dropchop.LayerList.js
+++ b/spec/suites/L.Dropchop.LayerList.js
@@ -1,4 +1,4 @@
-describe("L.DNC.LayerList", function () {
+describe("L.Dropchop.LayerList", function () {
     var map;
 
     beforeEach(function () {
@@ -13,7 +13,7 @@ describe("L.DNC.LayerList", function () {
         var layerlist;
 
         beforeEach(function () {
-            layerlist = new L.DNC.LayerList( map, { layerContainerId: 'dropzone' } );
+            layerlist = new L.Dropchop.LayerList( map, { layerContainerId: 'dropzone' } );
         });
 
         afterEach(function(){
@@ -34,7 +34,7 @@ describe("L.DNC.LayerList", function () {
         });
 
         it("intialized correctly", function () {
-            expect(layerlist instanceof L.DNC.LayerList).to.equal(true);
+            expect(layerlist instanceof L.Dropchop.LayerList).to.equal(true);
         });
 
     });
@@ -43,7 +43,7 @@ describe("L.DNC.LayerList", function () {
         var layerlist;
 
         beforeEach(function () {
-            layerlist = new L.DNC.LayerList( map, { layerContainerId: 'dropzone' } );
+            layerlist = new L.Dropchop.LayerList( map, { layerContainerId: 'dropzone' } );
         });
 
         afterEach(function(){
@@ -69,7 +69,7 @@ describe("L.DNC.LayerList", function () {
         var domElement;
 
         beforeEach(function () {
-            layerlist = new L.DNC.LayerList( map, { layerContainerId: 'dropzone' } );
+            layerlist = new L.Dropchop.LayerList( map, { layerContainerId: 'dropzone' } );
             layer = L.geoJson( window.testingData.polygon );
             domElement = layerlist._buildListItemDomElement({ name: name, layer: layer });
 
@@ -153,7 +153,7 @@ describe("L.DNC.LayerList", function () {
         var layerlist;
 
         beforeEach(function () {
-            layerlist = new L.DNC.LayerList( map, { layerContainerId: 'dropzone' } );
+            layerlist = new L.Dropchop.LayerList( map, { layerContainerId: 'dropzone' } );
             layer = L.geoJson( window.testingData.polygon );
             layerlist.addLayer(layer);
         });
@@ -164,7 +164,7 @@ describe("L.DNC.LayerList", function () {
             var returnedInstance = layerlist.removeLayer(layer);
 
             // assertions
-            expect(returnedInstance instanceof L.DNC.LayerList).to.equal(true);
+            expect(returnedInstance instanceof L.Dropchop.LayerList).to.equal(true);
             expect(typeof returnedInstance._layers[ lookupId ]).to.equal("undefined");
         });
 
@@ -177,7 +177,7 @@ describe("L.DNC.LayerList", function () {
         var mockMapRemoveLayer;
 
         beforeEach(function () {
-            layerlist = new L.DNC.LayerList( map, { layerContainerId: 'dropzone' } );
+            layerlist = new L.Dropchop.LayerList( map, { layerContainerId: 'dropzone' } );
             layer = L.geoJson( window.testingData.polygon );
             layerlist.domElement = document.createElement("div");
             layerlist.domElement.className = "test";
@@ -238,7 +238,7 @@ describe("L.DNC.LayerList", function () {
         var mockSelectRemove;
 
         beforeEach(function () {
-            layerlist = new L.DNC.LayerList( map, { layerContainerId: 'dropzone' } );
+            layerlist = new L.Dropchop.LayerList( map, { layerContainerId: 'dropzone' } );
             layer = L.geoJson( window.testingData.polygon );
             mockSelectAdd = sinon.spy(layerlist.selection, "add");
             mockSelectRemove = sinon.spy(layerlist.selection, "remove");

--- a/spec/suites/L.Dropchop.Menu.js
+++ b/spec/suites/L.Dropchop.Menu.js
@@ -1,8 +1,8 @@
-describe("L.DNC.Menu", function () {
+describe("L.Dropchop.Menu", function () {
     var menu = null;
     var title = "Test Menu";
     var items = [];
-    var parent = new L.DNC.MenuBar( { id: 'menu-bar' } );
+    var parent = new L.Dropchop.MenuBar( { id: 'menu-bar' } );
     var fakeOptions = { items: ['waka', 'flaka'], menuDirection: 'below' };
 
     var begin_html =
@@ -21,20 +21,20 @@ describe("L.DNC.Menu", function () {
 
 
     beforeEach(function () {
-        menu = new L.DNC.Menu( title, fakeOptions ).addTo( parent );
+        menu = new L.Dropchop.Menu( title, fakeOptions ).addTo( parent );
     });
 
 
     /*
     **
-    **  Ensures all options passed through L.DNC.Menu are properly
+    **  Ensures all options passed through L.Dropchop.Menu are properly
     **  intialized in the app and equalt their expected values.
     **
     */
     describe("initialize options", function () {
 
         it("is activated correctly", function () {
-            expect( menu instanceof L.DNC.Menu ).to.equal( true );
+            expect( menu instanceof L.Dropchop.Menu ).to.equal( true );
         });
 
         it("options correctly set", function () {
@@ -120,7 +120,7 @@ describe("L.DNC.Menu", function () {
 
         it("unexpands one menu when other menu is clicked", function () {
             // Setup
-            var menu2 = new L.DNC.Menu( "Second Menu", fakeOptions ).addTo( parent );
+            var menu2 = new L.Dropchop.Menu( "Second Menu", fakeOptions ).addTo( parent );
             var dropdown2 = menu2.domElement.getElementsByClassName('menu-dropdown')[0];
             document.body.appendChild(menu.domElement);
             document.body.appendChild(menu2.domElement);

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
   <title>Drip. Drop. Drip.</title>
 
   <script src="//api.tiles.mapbox.com/mapbox.js/v2.1.9/mapbox.js"></script>
+  <!-- <script src="//api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.0/turf.min.js"></script> -->
 
   <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
   <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
@@ -15,13 +16,12 @@
 <div id="sidebar"></div>
 <div id="map"></div>
 
-<!-- build:[src]:dev js/L.DNC.js -->
-<script src="js/vendor.min.js" type="text/javascript"></script>
-<script src="js/L.DNC.min.js" type="text/javascript"></script>
+<!-- build:[src]:dev js/dropchop.min.js -->
+<script src="js/bundle.js" type="text/javascript"></script>
 <!-- /build -->
 <script type="text/javascript">
     window.onload = function() {
-        L.DNC.app = new L.DNC.AppController();
+      L.Dropchop.app = new L.Dropchop.AppController();
     };
 </script>
 

--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,7 @@
 <div id="map"></div>
 
 <!-- build:[src]:dev js/dropchop.min.js -->
-<script src="js/bundle.js" type="text/javascript"></script>
+<script src="js/dropchop.min.js" type="text/javascript"></script>
 <!-- /build -->
 <script type="text/javascript">
     window.onload = function() {

--- a/src/js/L.Dropchop.js
+++ b/src/js/L.Dropchop.js
@@ -1,13 +1,15 @@
+var turf = require('turf');
+
 (function(){
-    var DNC = {
+    var Dropchop = {
         version: '0.0.1-dev'
     };
 
     if (typeof module === 'object' && typeof module.exports === 'object') {
-        module.exports = DNC;
+        module.exports = Dropchop;
     }
 
     if (typeof window !== 'undefined' && window.L ) {
-        window.L.DNC = DNC;
+        window.L.Dropchop = Dropchop;
     }
 })();

--- a/src/js/controller/AppController.js
+++ b/src/js/controller/AppController.js
@@ -1,11 +1,11 @@
-L.DNC = L.DNC || {};
+L.Dropchop = L.Dropchop || {};
 /*
 **
 ** AppController is the primary point of app initialization. It basically 'ties
 ** every together'
 **
 */
-L.DNC.AppController = L.Class.extend({
+L.Dropchop.AppController = L.Class.extend({
 
     statics: {},
 
@@ -18,53 +18,53 @@ L.DNC.AppController = L.Class.extend({
         // override defaults with passed options
         L.setOptions(this, options);
 
-        this.mapView = new L.DNC.MapView();
-        this.dropzone = new L.DNC.DropZone( this.mapView._map, {} );
-        this.layerlist = new L.DNC.LayerList( this.mapView._map, { layerContainerId: 'sidebar' } );
-        this.menubar = new L.DNC.MenuBar(
+        this.mapView = new L.Dropchop.MapView();
+        this.dropzone = new L.Dropchop.DropZone( this.mapView._map, {} );
+        this.layerlist = new L.Dropchop.LayerList( this.mapView._map, { layerContainerId: 'sidebar' } );
+        this.menubar = new L.Dropchop.MenuBar(
             { id: 'menu-bar' }
         ).addTo( document.body );
-        this.bottom_menu = new L.DNC.MenuBar(
+        this.bottom_menu = new L.Dropchop.MenuBar(
             { id: 'add-remove', classList: ["bottom", "menu"] }
         ).addTo( document.getElementById('sidebar') );
 
         // build out menus
         this.menus = {
             // GEO
-            geo: new L.DNC.Menu('Geoprocessing', {  // New dropdown menu
+            geo: new L.Dropchop.Menu('Geoprocessing', {  // New dropdown menu
                 items: ['bezier', 'buffer', 'center', 'centroid', 'envelope', 'union', 'tin']
             }).addTo( this.menubar ),                // Append to menubar
             
             // FILE
-            file: new L.DNC.Menu('File', {  // New dropdown menu
+            file: new L.Dropchop.Menu('File', {  // New dropdown menu
                 items: ['save geojson', 'save shapefile']          // Items in menu
             }).addTo( this.menubar ),         // Append to menubar
 
             // ADD LAYER
-            addLayer: new L.DNC.Menu('Add', {       // New dropdown menu
+            addLayer: new L.Dropchop.Menu('Add', {       // New dropdown menu
                 items: ['upload', 'load from url'],
                 menuDirection: 'above',
                 iconClassName: "fa fa-plus",
             }).addTo( this.bottom_menu ),           // Append to menubar
 
             // REMOVE LAYER
-            removeLayer: new L.DNC.Menu('Remove', {
+            removeLayer: new L.Dropchop.Menu('Remove', {
                 iconClassName: "fa fa-minus",
             }).addTo( this.bottom_menu ),
         };
 
         this.geoOpsConfig = {
-            operations: new L.DNC.Geo(),        // Configurations of GeoOperations
-            executor: new L.DNC.GeoExecute()    // Executor of GeoOperations
+            operations: new L.Dropchop.Geo(),        // Configurations of GeoOperations
+            executor: new L.Dropchop.GeoExecute()    // Executor of GeoOperations
         };
 
         this.fileOpsConfig = {
-            operations: new L.DNC.File(),        // Configurations of GeoOperations
-            executor: new L.DNC.FileExecute()    // Executor of GeoOperations
+            operations: new L.Dropchop.File(),        // Configurations of GeoOperations
+            executor: new L.Dropchop.FileExecute()    // Executor of GeoOperations
         };
 
-        this.forms = new L.DNC.Forms();
-        this.notification = new L.DNC.Notifications();
+        this.forms = new L.Dropchop.Forms();
+        this.notification = new L.Dropchop.Notifications();
         this._addEventHandlers();
 
     },

--- a/src/js/dropzone/DropZone.js
+++ b/src/js/dropzone/DropZone.js
@@ -1,5 +1,5 @@
-L.DNC = L.DNC || {};
-L.DNC.DropZone = L.Class.extend({
+L.Dropchop = L.Dropchop || {};
+L.Dropchop.DropZone = L.Class.extend({
 
 
     statics: {
@@ -16,9 +16,9 @@ L.DNC.DropZone = L.Class.extend({
         // override defaults with passed options
         L.setOptions(this, options);
         this._map = map;
-        this.type = L.DNC.DropZone.TYPE;
+        this.type = L.Dropchop.DropZone.TYPE;
 
-        this.fileReader = new L.DNC.DropZone.FileReader( this._map, options );
+        this.fileReader = new L.Dropchop.DropZone.FileReader( this._map, options );
         this.fileReader.enable();
     }
 

--- a/src/js/dropzone/handlers/DropZone.FileReader.js
+++ b/src/js/dropzone/handlers/DropZone.FileReader.js
@@ -1,5 +1,5 @@
-L.DNC.DropZone = L.DNC.DropZone || {};
-L.DNC.DropZone.FileReader = L.Handler.extend({
+L.Dropchop.DropZone = L.Dropchop.DropZone || {};
+L.Dropchop.DropZone.FileReader = L.Handler.extend({
     includes: L.Mixin.Events,
 
     // defaults

--- a/src/js/forms/Forms.js
+++ b/src/js/forms/Forms.js
@@ -1,5 +1,5 @@
-L.DNC = L.DNC || {};
-L.DNC.Forms = L.Class.extend({
+L.Dropchop = L.Dropchop || {};
+L.Dropchop.Forms = L.Class.extend({
     includes: L.Mixin.Events,
 
     options: {},

--- a/src/js/layerlist/LayerList.js
+++ b/src/js/layerlist/LayerList.js
@@ -1,5 +1,5 @@
-L.DNC = L.DNC || {};
-L.DNC.LayerList = L.Control.extend({
+L.Dropchop = L.Dropchop || {};
+L.Dropchop.LayerList = L.Control.extend({
 
     /*
     **

--- a/src/js/mapview/MapView.js
+++ b/src/js/mapview/MapView.js
@@ -1,5 +1,5 @@
-L.DNC = L.DNC || {};
-L.DNC.MapView = L.Class.extend({
+L.Dropchop = L.Dropchop || {};
+L.Dropchop.MapView = L.Class.extend({
 
     statics: {},
 

--- a/src/js/menus/Menu.js
+++ b/src/js/menus/Menu.js
@@ -1,11 +1,11 @@
-L.DNC = L.DNC || {};
+L.Dropchop = L.Dropchop || {};
 
 /*
 **
 ** A dropdown menu
 **
 */
-L.DNC.Menu = L.Class.extend({
+L.Dropchop.Menu = L.Class.extend({
     includes: L.Mixin.Events,
     options: { items: [], menuDirection: 'below' },
 

--- a/src/js/menus/MenuBar.js
+++ b/src/js/menus/MenuBar.js
@@ -1,5 +1,5 @@
-L.DNC = L.DNC || {};
-L.DNC.MenuBar = L.Class.extend({
+L.Dropchop = L.Dropchop || {};
+L.Dropchop.MenuBar = L.Class.extend({
     includes: L.Mixin.Events,
     options: { id: '#menu-bar', classList: [] },
 

--- a/src/js/notifications/Notifications.js
+++ b/src/js/notifications/Notifications.js
@@ -1,5 +1,5 @@
-L.DNC = L.DNC || {};
-L.DNC.Notifications = L.Class.extend({
+L.Dropchop = L.Dropchop || {};
+L.Dropchop.Notifications = L.Class.extend({
 
     statics: {},
 

--- a/src/js/operations/BaseExecute.js
+++ b/src/js/operations/BaseExecute.js
@@ -1,5 +1,5 @@
-L.DNC = L.DNC || {};
-L.DNC.BaseExecute = L.Class.extend({
+L.Dropchop = L.Dropchop || {};
+L.Dropchop.BaseExecute = L.Class.extend({
     includes: L.Mixin.Events,
 
     options: {},

--- a/src/js/operations/File.js
+++ b/src/js/operations/File.js
@@ -1,4 +1,4 @@
-L.DNC.File = L.Class.extend({
+L.Dropchop.File = L.Class.extend({
     includes: L.Mixin.Events,
 
     options: {},

--- a/src/js/operations/FileExecute.js
+++ b/src/js/operations/FileExecute.js
@@ -1,8 +1,8 @@
-// includes shp-write
+var shpwrite = require('shp-write');
 // includes filesaver.js
 
-L.DNC = L.DNC || {};
-L.DNC.FileExecute = L.DNC.BaseExecute.extend({
+L.Dropchop = L.Dropchop || {};
+L.Dropchop.FileExecute = L.Dropchop.BaseExecute.extend({
     includes: L.Mixin.Events,
 
     options: {},
@@ -45,7 +45,7 @@ L.DNC.FileExecute = L.DNC.BaseExecute.extend({
                 }
                 catch(err) {
                     console.log(err);
-                    L.DNC.app.notification.add({
+                    L.Dropchop.app.notification.add({
                         text: "Error downloading one of the shapefiles... please try downloading in another format",
                         type: 'alert',
                         time: 3500

--- a/src/js/operations/FileExecute.js
+++ b/src/js/operations/FileExecute.js
@@ -18,12 +18,6 @@ L.Dropchop.FileExecute = L.Dropchop.BaseExecute.extend({
             'save geojson': function ( action, parameters, options, layers, callback ) {
                 console.debug("Saving GeoJSON");
 
-                console.log(action);
-                console.log(parameters);
-                console.log(options);
-                console.log(layers);
-                console.log(callback);
-
                 for (var i=0; i<layers.length; i++) {
                     var prefix = parameters[0];
                     var content = JSON.stringify(layers[i].layer._geojson);
@@ -39,8 +33,16 @@ L.Dropchop.FileExecute = L.Dropchop.BaseExecute.extend({
                 console.debug("Saving Shapefile");
                 try {
                     for (var ii=0; ii<layers.length; ii++) {
+                        var shpOptions = {
+                            folder: 'myshapes',
+                            types: {
+                                point: 'mypoints',
+                                polygon: 'mypolygons',
+                                line: 'mylines'
+                            }
+                        };
                         console.log(layers[ii]);
-                        shpwrite.download(layers[ii].layer._geojson);
+                        shpwrite.download(layers[ii].layer._geojson, shpOptions);
                     }
                 }
                 catch(err) {

--- a/src/js/operations/Geo.js
+++ b/src/js/operations/Geo.js
@@ -1,4 +1,4 @@
-L.DNC.Geo = L.Class.extend({
+L.Dropchop.Geo = L.Class.extend({
     includes: L.Mixin.Events,
 
     options: {},

--- a/src/js/operations/GeoExecute.js
+++ b/src/js/operations/GeoExecute.js
@@ -1,5 +1,5 @@
-L.DNC = L.DNC || {};
-L.DNC.GeoExecute = L.DNC.BaseExecute.extend({
+L.Dropchop = L.Dropchop || {};
+L.Dropchop.GeoExecute = L.Dropchop.BaseExecute.extend({
     includes: L.Mixin.Events,
 
     options: {},

--- a/src/sass/_contextMenu.scss
+++ b/src/sass/_contextMenu.scss
@@ -1,0 +1,6 @@
+.context-menu {
+  position:absolute;
+  width:200px;
+  height:300px;
+  background-color:blue;
+}


### PR DESCRIPTION
* this does a complete rename to all `Dropchop` files, closes #120 
* runs `browserify` after concatenation into `bundle.js` then minified into `dropchop.min.js` for a full app usage. This means we are no longer using a `vendor.js` bundle or concatenating with `vendor` options in `grunt-browserify`. We are using real-life `require()`'s!

Running into some issues with `shpwrite` so going to work through those before merging this PR.