### PR TITLE
Develop against unminified bundle

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -138,7 +138,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['karma']);
   grunt.registerTask('lint', ['jshint']);
   // JS
-  grunt.registerTask('js:dev', ['jshint', 'concat', 'browserify', 'uglify', 'test']);
+  grunt.registerTask('js:dev', ['jshint', 'concat', 'browserify', 'test']);
   grunt.registerTask('js:prod', ['concat', 'browserify', 'uglify']);
   // CSS
   grunt.registerTask('css:dev', ['sass']);

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function (config) {
         files: [
             "node_modules/mapbox.js/src/index.js",
             "node_modules/turf/turf.js",
-            "dist/js/dropchop.min.js",
+            "dist/js/bundle.js",
             "spec/**/*.js",
         ],
         exclude: [],

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,6 @@
   <title>Drip. Drop. Drip.</title>
 
   <script src="//api.tiles.mapbox.com/mapbox.js/v2.1.9/mapbox.js"></script>
-  <!-- <script src="//api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.0/turf.min.js"></script> -->
 
   <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
   <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
@@ -16,7 +15,7 @@
 <div id="sidebar"></div>
 <div id="map"></div>
 
-<!-- build:[src]:dev js/dropchop.min.js -->
+<!-- build:[src]:dev js/bundle.js -->
 <script src="js/dropchop.min.js" type="text/javascript"></script>
 <!-- /build -->
 <script type="text/javascript">


### PR DESCRIPTION
Some changes were made to the Gruntfile that resulted in `grunt` command minifying the code during development.  This makes debugging more difficult.

These changes ensure that minification doesn't take place until `grunt prod` is run (or `grunt deploy`).