### PR TITLE
Add data from GET parameters

### DIFF
--- a/spec/suites/L.Dropchop.AppController.js
+++ b/spec/suites/L.Dropchop.AppController.js
@@ -1,0 +1,89 @@
+describe("L.Dropchop.AppController", function () {
+
+    describe("initialize", function () {
+        var map_div;
+        var sidebar_div;
+
+        beforeEach(function () {
+            map_div = document.createElement('div');
+            map_div.id = "map";
+            document.body.appendChild(map_div);
+
+            sidebar_div = document.createElement('div');
+            sidebar_div.id = "sidebar";
+            document.body.appendChild(sidebar_div);
+        });
+
+        afterEach(function () {
+            document.body.removeChild(map_div);
+            document.body.removeChild(sidebar_div);
+        });
+
+        it("calls _handleGetParams", function () {
+            sinon.spy(L.Dropchop.AppController.prototype, "_handleGetParams");
+
+            var app = new L.Dropchop.AppController();
+            expect(app._handleGetParams.calledOnce).to.be.true;
+
+            L.Dropchop.AppController.prototype._handleGetParams.restore();
+        });
+
+    });
+
+    describe("_getJsonFromUrl", function () {
+
+        afterEach(function () {
+            window.history.pushState(null, null, '/');
+        });
+
+        it("propery retrieves GET params", function () {
+            // Set URL
+            var url = '/?url=http://google.com&gist=1234&gist=456&url=http%3A%2F%2Fdropchop.io'
+            window.history.pushState(null, null, url);
+
+            expect(L.Dropchop.AppController.prototype._getJsonFromUrl()).to.eql(
+                {
+                    url: ['http://google.com', 'http://dropchop.io'],
+                    gist: ['1234', '456']
+                }
+            );
+        });
+    });
+
+    describe("_handleGetParams", function () {
+        var app;
+        var map_div;
+        var sidebar_div;
+
+        beforeEach(function () {
+            map_div = document.createElement('div');
+            map_div.id = "map";
+            document.body.appendChild(map_div);
+
+            sidebar_div = document.createElement('div');
+            sidebar_div.id = "sidebar";
+            document.body.appendChild(sidebar_div);
+            app = new L.Dropchop.AppController();
+        });
+
+        afterEach(function () {
+            document.body.removeChild(map_div);
+            document.body.removeChild(sidebar_div);
+            window.history.pushState(null, null, '/');
+        });
+
+        it("calls appropriate operations", function () {
+            var stub = sinon.stub(app, '_getJsonFromUrl').returns({
+                url: ['http://foo.com', 'http://bar.com'],
+                gist: ['abcd']
+            });
+
+            var mock = sinon.mock(app.fileOpsConfig.executor);
+            mock.expects('execute').withArgs('load from url', ['http://foo.com'], null, null);
+            mock.expects('execute').withArgs('load from url', ['http://bar.com'], null, null);
+            mock.expects('execute').withArgs('load from gist', ['abcd'], null, null);
+
+            app._handleGetParams();
+        });
+    });
+});

--- a/src/js/operations/File.js
+++ b/src/js/operations/File.js
@@ -47,5 +47,16 @@ L.Dropchop.File = L.Class.extend({
                 default: 'http://',
             },
         ],
+    },
+
+    'load from gist': {
+        description: 'Import files from a Github Gist',
+        parameters: [
+            {
+                name: 'gist',
+                description :'Gist ID or URL',
+                type: 'text',
+            },
+        ],
     }
 });


### PR DESCRIPTION
This allows a user to load data files into Dropchop by appending data sources to the URL (either `gist` or `url`). A user can append one or many data sources (provided that the URL stays under ~2000 characters). A `url` can be inputted as either a URL encoded or a URL decoded string. A `gist` can be inputted as the URL to the gist (eg `https://gist.github.com/alukach/0bf4471e44a0243b66db`) or the gist id (eg `0bf4471e44a0243b66db`). A 'load from gist' option was added to the 'Add' menu.

![load-from-url-get](https://cloud.githubusercontent.com/assets/897290/8147164/85b82612-121d-11e5-9a1d-82cd5922ff59.gif)

![gist-url](https://cloud.githubusercontent.com/assets/897290/8147071/7cc49d18-121a-11e5-9ac0-49dad829f153.gif)

I'm pretty happy with how this turned out.  It will allow people to more easily use Dropchop as a data viewer (as mentioned in #123). It also makes it a lot easier to populate the webpage with data during development.

Needs some tests and then will be good to go.