### PR TITLE
worldCopyJump: true

### DIFF
--- a/src/js/mapview/MapView.js
+++ b/src/js/mapview/MapView.js
@@ -26,7 +26,8 @@ L.Dropchop.MapView = L.Class.extend({
 
         L.mapbox.accessToken = 'pk.eyJ1Ijoic3ZtYXR0aGV3cyIsImEiOiJVMUlUR0xrIn0.NweS_AttjswtN5wRuWCSNA';
         this._map = L.mapbox.map('map', null, {
-            zoomControl: false
+            zoomControl: false,
+            worldCopyJump: true,
         }).setView([0,0], 3);
 
         var baseLayers = {


### PR DESCRIPTION
From the [docs](http://leafletjs.com/reference.html):

> With this option enabled, the map tracks when you pan to another "copy" of the world and seamlessly jumps to the original one so that all overlays like markers and vector layers are still visible.

Before:

![panning-bad](https://cloud.githubusercontent.com/assets/897290/8265615/c12f039c-16bd-11e5-98f6-80e03871b597.gif)

After:

![panning-good](https://cloud.githubusercontent.com/assets/897290/8265616/c52573fa-16bd-11e5-8938-45b4d78caad7.gif)

I feel like this setting can feel a bit 'glitchy' (jumps around, that weird reload flash that occurs, etc) but that's a problem with Leaflet itself and not Dropchop.  Hopefully it should get better.