### PR TITLE
Avoid global import of notifications

### DIFF
--- a/src/js/controller/AppController.js
+++ b/src/js/controller/AppController.js
@@ -21,6 +21,8 @@ L.Dropchop.AppController = L.Class.extend({
         this.mapView = new L.Dropchop.MapView();
         this.dropzone = new L.Dropchop.DropZone( this.mapView._map, {} );
         this.layerlist = new L.Dropchop.LayerList( this.mapView._map, { layerContainerId: 'sidebar' } );
+        this.notification = new L.Dropchop.Notifications();
+
         this.menubar = new L.Dropchop.MenuBar(
             { id: 'menu-bar' }
         ).addTo( document.body );
@@ -63,11 +65,12 @@ L.Dropchop.AppController = L.Class.extend({
 
         this.fileOpsConfig = {
             operations: new L.Dropchop.File(),        // Configurations of FileOperations
-            executor: new L.Dropchop.FileExecute()    // Executor of FileOperations
+            executor: new L.Dropchop.FileExecute(     // Executor of FileOperations
+                {'notifications': this.notification}
+            )
         };
 
         this.forms = new L.Dropchop.Forms();
-        this.notification = new L.Dropchop.Notifications();
         this._addEventHandlers();
         this._handleGetParams();
     },

--- a/src/js/controller/AppController.js
+++ b/src/js/controller/AppController.js
@@ -60,14 +60,12 @@ L.Dropchop.AppController = L.Class.extend({
 
         this.geoOpsConfig = {
             operations: new L.Dropchop.Geo(),        // Configurations of GeoOperations
-            executor: new L.Dropchop.TurfExecute()   // Executor of GeoOperations
+            executor: new L.Dropchop.TurfExecute( this.notification )   // Executor of GeoOperations
         };
 
         this.fileOpsConfig = {
             operations: new L.Dropchop.File(),        // Configurations of FileOperations
-            executor: new L.Dropchop.FileExecute(     // Executor of FileOperations
-                {'notifications': this.notification}
-            )
+            executor: new L.Dropchop.FileExecute( this.notification ) // Executor of FileOperations
         };
 
         this.forms = new L.Dropchop.Forms();

--- a/src/js/operations/BaseExecute.js
+++ b/src/js/operations/BaseExecute.js
@@ -4,6 +4,12 @@ L.Dropchop.BaseExecute = L.Class.extend({
 
     options: {},
 
+    initialize: function (notification, options) {
+        self.notification = notification;
+        // override defaults with passed options
+        L.setOptions(this, options);
+    },
+
     /*
     **
     ** EXECUTE OPERATIONS FROM INPUT

--- a/src/js/operations/FileExecute.js
+++ b/src/js/operations/FileExecute.js
@@ -115,12 +115,12 @@ L.Dropchop.FileExecute = L.Dropchop.BaseExecute.extend({
 
         xhr.onload = callback.bind(this, xhr);
         xhr.onerror = function( xhr ) {
+            console.error(xhr);
             this.notification.add({
                 text: 'Unable to access ' + url,
                 type: 'alert',
                 time: 2500
             });
-            console.error(xhr);
         };
 
         xhr.send();

--- a/src/js/operations/FileExecute.js
+++ b/src/js/operations/FileExecute.js
@@ -46,7 +46,7 @@ L.Dropchop.FileExecute = L.Dropchop.BaseExecute.extend({
                 }
                 catch(err) {
                     console.error(err);
-                    this.options.notifications.add({
+                    this.notification.add({
                         text: "Error downloading one of the shapefiles... please try downloading in another format",
                         type: 'alert',
                         time: 3500
@@ -115,7 +115,7 @@ L.Dropchop.FileExecute = L.Dropchop.BaseExecute.extend({
 
         xhr.onload = callback.bind(this, xhr);
         xhr.onerror = function( xhr ) {
-            this.options.notifications.add({
+            this.notification.add({
                 text: 'Unable to access ' + url,
                 type: 'alert',
                 time: 2500
@@ -154,12 +154,12 @@ L.Dropchop.FileExecute = L.Dropchop.BaseExecute.extend({
 
             return callback( { add: [{ geometry: newLayer, name: filename }] } );
         } catch(err) {
-            this.options.notifications.add({
+            console.error(err);
+            this.notification.add({
                 text: 'Failed to add ' + filename,
                 type: 'alert',
                 time: 2500
             });
-            console.error(err);
             return;
         }
     }

--- a/src/js/operations/FileExecute.js
+++ b/src/js/operations/FileExecute.js
@@ -46,7 +46,7 @@ L.Dropchop.FileExecute = L.Dropchop.BaseExecute.extend({
                 }
                 catch(err) {
                     console.error(err);
-                    L.Dropchop.app.notification.add({
+                    this.options.notifications.add({
                         text: "Error downloading one of the shapefiles... please try downloading in another format",
                         type: 'alert',
                         time: 3500
@@ -112,7 +112,17 @@ L.Dropchop.FileExecute = L.Dropchop.BaseExecute.extend({
     getRequest: function ( url, callback ) {
         var xhr = new XMLHttpRequest();
         xhr.open('GET', encodeURI(url));
+
         xhr.onload = callback.bind(this, xhr);
+        xhr.onerror = function( xhr ) {
+            this.options.notifications.add({
+                text: 'Unable to access ' + url,
+                type: 'alert',
+                time: 2500
+            });
+            console.error(xhr);
+        };
+
         xhr.send();
     },
 
@@ -144,7 +154,7 @@ L.Dropchop.FileExecute = L.Dropchop.BaseExecute.extend({
 
             return callback( { add: [{ geometry: newLayer, name: filename }] } );
         } catch(err) {
-            L.Dropchop.app.notification.add({
+            this.options.notifications.add({
                 text: 'Failed to add ' + filename,
                 type: 'alert',
                 time: 2500


### PR DESCRIPTION
The way we are importing from `L.Dropchop.app` feels weird (and makes it difficult to test).

I would prefer to solve this via signals but it seems like you have to connect the `notifications` listener to ever signal sender, which seems laborious.  Instead, I opted to pass the notification tooling to the executor as an option.  This pattern can be applied to anything that would call `notifications`.