### PR TITLE
Buildout tests for gist / url loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "karma-phantomjs-launcher": "~0.1.4",
     "karma-sinon": "~1.0.4",
     "mocha": "^2.2.4",
-    "sinon": "~1.14.1"
+    "sinon": "^1.15.0"
   },
   "dependencies": {
     "browser-filesaver": "^1.0.0",

--- a/spec/suites/L.Dropchop.AppController.js
+++ b/spec/suites/L.Dropchop.AppController.js
@@ -84,6 +84,9 @@ describe("L.Dropchop.AppController", function () {
             mock.expects('execute').withArgs('load from gist', ['abcd'], null, null);
 
             app._handleGetParams();
+
+            mock.restore();
+            stub.restore();
         });
     });
 });

--- a/spec/suites/L.Dropchop.File.js
+++ b/spec/suites/L.Dropchop.File.js
@@ -1,15 +1,232 @@
 describe("L.Dropchop.FileExecute Operations", function(){
-	var menu;
-	var ops;
-	var exampleData = true;
 
-	// TODO: test for geojson save
-	describe('Save as a geojson', function () {
-		expect(exampleData).to.eql(true);
-	});
+    var menu;
+    var ops;
+    var exampleData = true;
 
-	// TODO: test for shapefile save
-	describe('Save as a shapefile', function () {
-		expect(exampleData).to.eql(true);
-	});
+    describe('Save as a geojson', function () {
+        // TODO: test for geojson save
+    });
+
+    describe('Save as a shapefile', function () {
+        // TODO: test for shapefile save
+    });
+
+    describe('load from url', function () {
+        var xhr, requests, getRequest, _addJsonAsLayer, fakeThis;
+
+        beforeEach(function () {
+            xhr = sinon.useFakeXMLHttpRequest();
+            requests = [];
+            xhr.onCreate = function (req) { requests.push(req); };
+
+            fakeThis = {
+                _addJsonAsLayer: function () {},
+                getRequest: function () {}
+            };
+            _addJsonAsLayer = sinon.stub(fakeThis, '_addJsonAsLayer');
+            getRequest = sinon.stub(fakeThis, 'getRequest');
+
+            console.debug = sinon.stub(console, "debug");
+            console.error = sinon.stub(console, "error");
+        });
+
+        afterEach(function () {
+            xhr.restore();
+            _addJsonAsLayer.restore();
+            getRequest.restore();
+            console.debug.restore();
+            console.error.restore();
+        });
+
+        it('makes request', function () {
+            L.Dropchop.FileExecute.prototype.execute.bind(fakeThis)(
+                'load from url', ['http://foo.com/blah.geojson'], null, null, null
+            );
+
+            expect(getRequest.calledOnce).to.equal(true);
+
+            // Ensure that getRequest is called with a URL and callback
+            var args = getRequest.firstCall.args;
+            expect(args.length).to.equal(2);
+            expect(args[0]).to.equal('http://foo.com/blah.geojson');
+            expect(typeof args[1]).to.equal('function');
+        });
+
+        it('callback logs bad request', function () {
+            L.Dropchop.FileExecute.prototype.execute.bind(fakeThis)(
+                'load from url', ['http://foo.com/blah.geojson'], null, null, null
+            );
+
+            // Ensure that when callback gets a non-200 response, error is logged
+            var args = getRequest.firstCall.args;
+            var ajaxCallback = args[1];
+            xhr.status = 500;
+            ajaxCallback(xhr)
+
+            expect(console.error.calledOnce).to.equal(true);
+            expect(console.error.firstCall.args).to.eql(['Request failed. Returned status of 500']);
+        });
+
+        it('callback creates layer from good request', function () {
+            var fakeCallback = function(){};
+            L.Dropchop.FileExecute.prototype.execute.bind(fakeThis)(
+                'load from url', ['http://foo.com/blah.geojson'], null, null, fakeCallback
+            );
+
+            // Ensure that when callback gets a 200 response, adds data as layer
+            var args = getRequest.firstCall.args;
+            var ajaxCallback = args[1];
+            xhr.status = 200;
+            xhr.responseURL = 'http://foo.com/blah.geojson';
+            xhr.responseText = "some geojson data goes here";
+            ajaxCallback.bind(fakeThis)(xhr)
+
+            expect(_addJsonAsLayer.calledOnce).to.equal(true);
+            expect(_addJsonAsLayer.firstCall.args).to.eql(['some geojson data goes here', 'blah.geojson', fakeCallback]);
+        });
+
+    });
+
+    describe('load from gist', function () {
+        var xhr, requests, getRequest, _addJsonAsLayer, fakeThis;
+
+        beforeEach(function () {
+            xhr = sinon.useFakeXMLHttpRequest();
+            requests = [];
+            xhr.onCreate = function (req) { requests.push(req); };
+
+            fakeThis = {
+                _addJsonAsLayer: function () {},
+                getRequest: function () {}
+            };
+            _addJsonAsLayer = sinon.stub(fakeThis, '_addJsonAsLayer');
+            getRequest = sinon.stub(fakeThis, 'getRequest');
+
+            console.debug = sinon.stub(console, "debug");
+            console.error = sinon.stub(console, "error");
+        });
+
+        afterEach(function () {
+            xhr.restore();
+            _addJsonAsLayer.restore();
+            getRequest.restore();
+            console.debug.restore();
+            console.error.restore();
+        });
+
+        it('makes request', function () {
+            L.Dropchop.FileExecute.prototype.execute.bind(fakeThis)(
+                'load from gist', ['1234'], null, null, null
+            );
+
+            expect(getRequest.calledOnce).to.equal(true);
+
+            // Ensure that getRequest is called with a URL and callback
+            var args = getRequest.firstCall.args;
+            expect(args.length).to.equal(2);
+            expect(args[0]).to.equal('https://api.github.com/gists/1234');
+            expect(typeof args[1]).to.equal('function');
+        });
+
+        it('callback logs bad request', function () {
+            L.Dropchop.FileExecute.prototype.execute.bind(fakeThis)(
+                'load from gist', ['1234'], null, null, null
+            );
+
+            // Ensure that when callback gets a non-200 response, error is logged
+            var args = getRequest.firstCall.args;
+            var ajaxCallback = args[1];
+            xhr.status = 500;
+            ajaxCallback(xhr)
+
+            expect(console.error.calledOnce).to.equal(true);
+            expect(console.error.firstCall.args).to.eql(['Request failed. Returned status of 500']);
+        });
+
+        it('callback creates layer from good request', function () {
+            var fakeCallback = function(){};
+            L.Dropchop.FileExecute.prototype.execute.bind(fakeThis)(
+                'load from gist', ['1234'], null, null, fakeCallback
+            );
+
+            // Ensure that when callback gets a 200 response, adds data as layer
+            var args = getRequest.firstCall.args;
+            var ajaxCallback = args[1];
+            xhr.status = 200;
+            xhr.responseURL = 'https://api.github.com/gists/1234';
+            xhr.responseText = "{\"files\": {\"foo.js\": {\"content\": \"some geojson data goes here\", \"filename\": \"foo.js\"}}}";
+            // xhr.responseText = "some geojson data goes here";
+            ajaxCallback.bind(fakeThis)(xhr);
+
+            expect(_addJsonAsLayer.calledOnce).to.equal(true);
+            expect(_addJsonAsLayer.firstCall.args).to.eql(['some geojson data goes here', 'foo.js', fakeCallback]);
+        });
+    });
+
+    describe('getRequest', function () {
+        var xhr, requests, getRequest, _addJsonAsLayer, fakeThis;
+
+        beforeEach(function () {
+            xhr = sinon.useFakeXMLHttpRequest();
+            requests = [];
+            xhr.onCreate = function (req) { requests.push(req); };
+        });
+
+        afterEach(function () {
+            xhr.restore();
+        });
+
+        it('requests provided url, calls callback', function () {
+            var callback = sinon.spy();
+            L.Dropchop.FileExecute.prototype.getRequest('http://google.com', callback);
+
+            expect(requests.length).to.equal(1);
+            expect(requests[0].url).to.equal('http://google.com');
+            // expect(callback.called).to.equal(true);  // TODO: We should assert that the callback is called with proper results data. This seems to fail for some reason.
+        });
+
+    });
+
+    describe('_addJsonAsLayer', function () {
+
+        var callback, notification;
+        beforeEach(function () {
+            callback = sinon.stub();
+        });
+
+        it("calls callback properly", function () {
+            L.Dropchop.FileExecute.prototype._addJsonAsLayer('{}', 'filename.json', callback);
+            expect(callback.calledOnce).to.equal(true);
+            expect(callback.firstCall.args).to.eql(
+                [{ add: [{ geojson: {}, name: 'filename.json' }] }]
+            );
+        });
+
+        it("notifies on failure", function () {
+            var fakeThis = {notification: {add: sinon.stub()}};
+            console.error = sinon.stub(console, "error");
+            L.Dropchop.FileExecute.prototype._addJsonAsLayer.bind(fakeThis)('bad json', 'filename.json', callback);
+            expect(console.error.called).to.equal(true);
+            console.error.restore();
+            expect(callback.calledOnce).to.equal(false);
+            expect(fakeThis.notification.add.called).to.equal(true);
+            expect(fakeThis.notification.add.firstCall.args).to.eql([{
+                text: 'Failed to add filename.json',
+                type: 'alert',
+                time: 2500
+            }]);
+        });
+
+        it("uncollects single-length featurecollections", function () {
+            var fakeThis = L.Dropchop.FileExecute.prototype;
+            fakeThis.notification = {add: sinon.stub()};
+            var featurecollection = "{\"type\":\"FeatureCollection\",\"features\":[{\"foo\":\"bar\"}]}";
+            L.Dropchop.FileExecute.prototype._addJsonAsLayer.bind(fakeThis)(featurecollection, 'filename.json', callback);
+            expect(callback.calledOnce).to.equal(true);
+            expect(callback.firstCall.args).to.eql(
+                [{ add: [{ geojson: {foo: "bar"}, name: 'filename.json' }] }]
+            );
+        });
+    });
 });

--- a/spec/suites/L.Dropchop.Geo.js
+++ b/spec/suites/L.Dropchop.Geo.js
@@ -49,7 +49,7 @@ describe("L.Dropchop.TurfExecute", function () {
             assert(callback.calledWith({
                 add: [{
                     name: "along_line.geojson",
-                    geometry: {"type":"Feature","geometry":{"type":"Point","coordinates":[-10.839132601858164,38.352329563649434]},"properties":{}}
+                    geojson: {"type":"Feature","geometry":{"type":"Point","coordinates":[-10.839132601858164,38.352329563649434]},"properties":{}}
                 }]
             }));
         });
@@ -86,7 +86,7 @@ describe("L.Dropchop.TurfExecute", function () {
             assert(callback.calledWith({
                 add: [{
                     name: "bezier_line.geojson",
-                    geometry: {
+                    geojson: {
                         "type": "Feature",
                         "geometry": {
                             "type": "LineString",
@@ -130,7 +130,7 @@ describe("L.Dropchop.TurfExecute", function () {
             assert(callback.calledWith({
                 add: [{
                     name: "buffer_union1.geojson",
-                    geometry: {
+                    geojson: {
                       "type":"Feature",
                       "geometry":{
                         "type":"Polygon",
@@ -214,7 +214,7 @@ describe("L.Dropchop.TurfExecute", function () {
             assert(callback.calledWith({
                 add: [{
                     name: "center_center1.geojson",
-                    geometry: {
+                    geojson: {
                         "type": "Feature",
                         "geometry": {
                             "type": "Point",
@@ -259,7 +259,7 @@ describe("L.Dropchop.TurfExecute", function () {
             assert(callback.calledWith({
                 add: [{
                     name: "centroid_center1.geojson",
-                    geometry: {
+                    geojson: {
                         "type": "Feature",
                         "geometry": {
                             "type": "Point",
@@ -299,7 +299,7 @@ describe("L.Dropchop.TurfExecute", function () {
 
 
             var callback = sinon.spy();
-            
+
             ops.geox.execute(
                 formData.action,
                 formData.parameters,
@@ -311,7 +311,7 @@ describe("L.Dropchop.TurfExecute", function () {
             assert(callback.calledWith({
                 add: [{
                     name: 'destination_point.geojson',
-                    geometry: {
+                    geojson: {
                       "type": "Feature",
                       "geometry": {
                         "type": "Point",
@@ -359,7 +359,7 @@ describe("L.Dropchop.TurfExecute", function () {
             assert(callback.calledWith({
                 add: [{
                     name: "envelope_feature.geojson",
-                    geometry: {
+                    geojson: {
                         "type": "Feature",
                         "geometry": {
                             "type": "Polygon",
@@ -427,7 +427,7 @@ describe("L.Dropchop.TurfExecute", function () {
             assert(callback.calledWith({
                 add: [{
                     name: "explode_polygon.geojson",
-                    geometry: {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[-122.33714103698729,47.64000546596801]},"properties":{}},{"type":"Feature","geometry":{"type":"Point","coordinates":[-122.33714103698729,47.640583778456666]},"properties":{}},{"type":"Feature","geometry":{"type":"Point","coordinates":[-122.33593940734862,47.640583778456666]},"properties":{}},{"type":"Feature","geometry":{"type":"Point","coordinates":[-122.33593940734862,47.64000546596801]},"properties":{}},{"type":"Feature","geometry":{"type":"Point","coordinates":[-122.33714103698729,47.64000546596801]},"properties":{}}]}
+                    geojson: {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[-122.33714103698729,47.64000546596801]},"properties":{}},{"type":"Feature","geometry":{"type":"Point","coordinates":[-122.33714103698729,47.640583778456666]},"properties":{}},{"type":"Feature","geometry":{"type":"Point","coordinates":[-122.33593940734862,47.640583778456666]},"properties":{}},{"type":"Feature","geometry":{"type":"Point","coordinates":[-122.33593940734862,47.64000546596801]},"properties":{}},{"type":"Feature","geometry":{"type":"Point","coordinates":[-122.33714103698729,47.64000546596801]},"properties":{}}]}
                 }]
             }));
         });
@@ -463,7 +463,7 @@ describe("L.Dropchop.TurfExecute", function () {
 
 
             var callback = sinon.spy();
-            
+
             ops.geox.execute(
                 formData.action,
                 formData.parameters,
@@ -475,7 +475,7 @@ describe("L.Dropchop.TurfExecute", function () {
             assert(callback.calledWith({
                 add: [{
                     name: 'midpoint_one_two.geojson',
-                    geometry: {"type":"Feature","geometry":{"type":"Point","coordinates":[-82.79296875,37.150939581046316]},"properties":{}}
+                    geojson: {"type":"Feature","geometry":{"type":"Point","coordinates":[-82.79296875,37.150939581046316]},"properties":{}}
                 }]
             }));
         });
@@ -504,7 +504,7 @@ describe("L.Dropchop.TurfExecute", function () {
             ];
 
             var callback = sinon.spy();
-            
+
             ops.geox.execute(
                 formData.action,
                 formData.parameters,
@@ -516,7 +516,7 @@ describe("L.Dropchop.TurfExecute", function () {
             assert(callback.calledWith({
                 add: [{
                     name: 'simplify_sf.geojson',
-                    geometry: {"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-122.47970581054688,37.80761398306056],[-122.51815795898436,37.57179370689751],[-122.20367431640624,37.53913285079332],[-122.47970581054688,37.80761398306056]]]},"properties":{}}
+                    geojson: {"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-122.47970581054688,37.80761398306056],[-122.51815795898436,37.57179370689751],[-122.20367431640624,37.53913285079332],[-122.47970581054688,37.80761398306056]]]},"properties":{}}
                 }]
             }));
         });
@@ -553,7 +553,7 @@ describe("L.Dropchop.TurfExecute", function () {
             assert(callback.calledWith({
                 add: [{
                     name: "tin_points.geojson",
-                    geometry: {
+                    geojson: {
                         "type": "Feature",
                         "geometry": {
                             "type": "Polygon",

--- a/src/js/controller/AppController.js
+++ b/src/js/controller/AppController.js
@@ -21,6 +21,8 @@ L.Dropchop.AppController = L.Class.extend({
         this.mapView = new L.Dropchop.MapView();
         this.dropzone = new L.Dropchop.DropZone( this.mapView._map, {} );
         this.layerlist = new L.Dropchop.LayerList( this.mapView._map, { layerContainerId: 'sidebar' } );
+        this.notification = new L.Dropchop.Notifications();
+
         this.menubar = new L.Dropchop.MenuBar(
             { id: 'menu-bar' }
         ).addTo( document.body );
@@ -68,16 +70,15 @@ L.Dropchop.AppController = L.Class.extend({
 
         this.geoOpsConfig = {
             operations: new L.Dropchop.Geo(),        // Configurations of GeoOperations
-            executor: new L.Dropchop.TurfExecute()   // Executor of GeoOperations
+            executor: new L.Dropchop.TurfExecute( this.notification )   // Executor of GeoOperations
         };
 
         this.fileOpsConfig = {
             operations: new L.Dropchop.File(),        // Configurations of FileOperations
-            executor: new L.Dropchop.FileExecute()    // Executor of FileOperations
+            executor: new L.Dropchop.FileExecute( this.notification ) // Executor of FileOperations
         };
 
         this.forms = new L.Dropchop.Forms();
-        this.notification = new L.Dropchop.Notifications();
         this._addEventHandlers();
         this._handleGetParams();
     },
@@ -179,7 +180,7 @@ L.Dropchop.AppController = L.Class.extend({
         if (resultPkg.add && resultPkg.add.length) {
             for (i = 0; i < resultPkg.add.length; i++) {
                 obj = resultPkg.add[i];
-                var mapLayer = L.mapbox.featureLayer( obj.geometry );
+                var mapLayer = L.mapbox.featureLayer( obj.geojson );
                 this.layerlist.addLayer( mapLayer, obj.name );
 
                 this.notification.add({

--- a/src/js/operations/BaseExecute.js
+++ b/src/js/operations/BaseExecute.js
@@ -4,6 +4,12 @@ L.Dropchop.BaseExecute = L.Class.extend({
 
     options: {},
 
+    initialize: function (notification, options) {
+        self.notification = notification;
+        // override defaults with passed options
+        L.setOptions(this, options);
+    },
+
     /*
     **
     ** EXECUTE OPERATIONS FROM INPUT

--- a/src/js/operations/TurfExecute.js
+++ b/src/js/operations/TurfExecute.js
@@ -22,14 +22,14 @@ L.Dropchop.TurfExecute = L.Dropchop.BaseExecute.extend({
 
         // Call func
         var newLayer = {
-            geometry: turf[this.action].apply(null, params),
+            geojson: turf[this.action].apply(null, params),
             name: this.action + '_' + name + '.geojson'
         };
 
         // if the new object is a feature collection and only has one layer,
         // remove it and just keep it as a feature
-        if ( newLayer.geometry.type == "FeatureCollection" && newLayer.geometry.features.length == 1 ) {
-            newLayer.geometry = this._unCollect( newLayer.geometry );
+        if ( newLayer.geojson.type == "FeatureCollection" && newLayer.geojson.features.length == 1 ) {
+            newLayer.geojson = this._unCollect( newLayer.geojson );
         }
 
         callback({ add: [newLayer] });


### PR DESCRIPTION
A series of tests to accompany #130.

Finally feeling strong about my JavaScript testing game :muscle:, I think this covers the features well.

Also, modified the format of the `resultsPkg` sent back from operations:

Old:
```
{
    add: [{
        name: "along_line.geojson",
        geometry: {"type":"Feature","geometry":{"type":"Point","coordinates":[-10.839132601858164,38.352329563649434]},"properties":{}}
    }]
}
```

New:
```
{
    add: [{
        name: "along_line.geojson",
        geojson: {"type":"Feature","geometry":{"type":"Point","coordinates":[-10.839132601858164,38.352329563649434]},"properties":{}}
    }]
}
```
It felt a bit confusing to use `geometry` as a key when the data has a `geometry` key within it.