### PR TITLE
creates tag_ properties for overpass tag object, fixes #185

### DIFF
--- a/src/js/ops.file.dropchop.js
+++ b/src/js/ops.file.dropchop.js
@@ -144,11 +144,37 @@ var dropchop = (function(dc) {
           if (!data.elements.length) {
             dc.notify('info', 'No elements found in your query.');
           } else {
-            $(dc).trigger('file:added', [dc.ops.file['load-overpass']._temp.layerName, geojson]);
+            var gj = tagsToAttributes(geojson);
+            $(dc).trigger('file:added', [dc.ops.file['load-overpass']._temp.layerName, gj]);
             dc.notify('success', 'Found <strong>' + data.elements.length + ' elements</strong> from the Overpass API');
           }
         } else {
           dc.notify('error', xhr.status + ': could not query the Overpass API');
+        }
+
+        // turns overpass response tags and meta properties into their own top-level properties
+        function tagsToAttributes(geojson) {
+          var g = geojson;
+          
+          // loop through each feature
+          for (var f = 0; f < g.features.length; f++) {
+
+            // loop through properties.tags object to create new top-level tag_ properties
+            if (Object.keys(g.features[f].properties.tags).length) {
+              for (var tag in g.features[f].properties.tags) {
+                g.features[f].properties['tag_'+tag] = g.features[f].properties.tags[tag];
+              }  
+            }
+
+            // loop through properties.meta object to create new top-level meta_ properties
+            if (Object.keys(g.features[f].properties.meta).length) {
+              for (var m in g.features[f].properties.meta) {
+                g.features[f].properties['meta_'+m] = g.features[f].properties.meta[m];
+              }  
+            }
+          }
+
+          return g;
         }
       }
     },


### PR DESCRIPTION
* loops through `properties.tags` in Overpass responses to make sure tag information is added as a top-level property for popups. Also does this for `properties.meta` if they exist.

<img width="318" alt="screen shot 2015-10-12 at 11 16 06 am" src="https://cloud.githubusercontent.com/assets/1943001/10432721/b9d33a5e-70d2-11e5-8841-db824c616398.png">
