### PR TITLE
Add support for dropchopping a zipped shapefile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,6 +37,7 @@ var vendorJS = [
   './node_modules/jquery/dist/jquery.js',
   './node_modules/browser-filesaver/FileSaver.js',
   './node_modules/shp-write/shpwrite.js',
+  './node_modules/shpjs/dist/shp.min.js',
   './src/lib/shp-2-geojson.js',
   './node_modules/osmtogeojson/osmtogeojson.js',
   './node_modules/turf/turf.js',

--- a/src/js/map.dropchop.js
+++ b/src/js/map.dropchop.js
@@ -1,5 +1,5 @@
 var dropchop = (function(dc) {
-  
+
   'use strict';
 
   dc = dc || {};
@@ -118,7 +118,7 @@ var dropchop = (function(dc) {
     dc.map.layergroup.addLayer(fl);
 
     // create popup table for each feature
-    fl.eachLayer(function(layer) {      
+    fl.eachLayer(function(layer) {
       var content = '<table class="dropchop-table"><tr><th>Property</th><th>Data</th></tr>';
 
       if (layer.feature.properties) {
@@ -147,7 +147,7 @@ var dropchop = (function(dc) {
   dc.map.showLayer = function(event, layer) {
     dc.map.layergroup.addLayer(layer.featurelayer);
   };
-  
+
   dc.map.removeLayer = function(event, stamp) {
     dc.map.layergroup.removeLayer(dc.layers.list[stamp].featurelayer);
   };

--- a/src/js/util.dropchop.js
+++ b/src/js/util.dropchop.js
@@ -1,11 +1,11 @@
 var dropchop = (function(dc) {
-  
+
   'use strict';
 
   dc = dc || {};
-  
+
   dc.util = {};
-  
+
   dc.util.removeFileExtension = function(string) {
     string = string.replace(/\.[^/.]+$/, "");
     return string;
@@ -43,13 +43,15 @@ var dropchop = (function(dc) {
     var reader = new FileReader();
     // if a zipfile, assume shapefile for now
     if (file.name.indexOf('.zip') > -1 || file.name.indexOf('.shp') > -1) {
-      console.log(file);
       reader.readAsArrayBuffer(file);
       reader.onloadend = function(event) {
-        console.log(reader);
-        shp(reader.result).then(forwardToGeoJsonIo);
+        console.log('Loading shapefile...');
+        shp(reader.result).then(function(geojson) {
+          console.log('...and done loading shapefile');
+          $(dc).trigger('file:added', [geojson.fileName, geojson]);
+        });
       };
-    } else { 
+    } else {
       reader.readAsText(file, 'UTF-8');
       reader.onload = function() {
         $(dc).trigger('file:added', [file.name, JSON.parse(reader.result)]);
@@ -131,7 +133,7 @@ var dropchop = (function(dc) {
     }
 
     return newFC;
-    
+
   };
 
   dc.util.loader = function(yes) {

--- a/src/js/util.dropchop.js
+++ b/src/js/util.dropchop.js
@@ -44,10 +44,10 @@ var dropchop = (function(dc) {
     // if a zipfile, assume shapefile for now
     if (file.name.indexOf('.zip') > -1 || file.name.indexOf('.shp') > -1) {
       reader.readAsArrayBuffer(file);
+      dc.util.loader(true);
       reader.onloadend = function(event) {
-        console.log('Loading shapefile...');
         shp(reader.result).then(function(geojson) {
-          console.log('...and done loading shapefile');
+          dc.util.loader(false);
           $(dc).trigger('file:added', [geojson.fileName, geojson]);
         });
       };


### PR DESCRIPTION
Sorry about the weird diff...apparently Atom likes to add a line break to the end of files and mess around with whitespace.

Added the ability to drag and drop a zipped shapefile using [shapefile-js](https://github.com/calvinmetcalf/shapefile-js). Fortunately it was already a dependency and mostly coded, just had to wire a couple of things together.

The shapefile-js function previously used `forwardToGeoJsonIo` as a callback, which I modified to instead trigger a `file:added` event. Not sure if that breaks anything or not, but it didn't seem like it.

Also had to tweak the gulpfile to make sure that `shapefile-js` is compressed into the dependencies.

Hopefully closes #10. Let me know what you think!