### PR TITLE
Rework URL parser to handle URLs that contain ampersands

### DIFF
--- a/src/js/util.dropchop.js
+++ b/src/js/util.dropchop.js
@@ -66,15 +66,26 @@ var dropchop = (function(dc) {
   };
 
   dc.util.jsonFromUrl = function() {
-    var query = location.search.substr(1);
-    var result = {};
-    query.split("&").forEach(function(part) {
-      var item = part.split("=");
-      if (!result[item[0]]) {
-        result[item[0]] = [];
+    var query = location.search.substr(1)
+      .split(/(&?gist=|&?url=)/g)
+      .filter(function(d) {
+        return d.length > 0;
+      });
+
+    var result = {}
+
+    query.forEach(function(part, i) {
+      if (i === 0 || i % 2 === 0) {
+        var key = part.replace(/&|=/g, '');
+
+        if (!result[key]) {
+          result[key] = []
+        }
+
+        result[key].push(decodeURIComponent(query[i + 1]));
       }
-      result[item[0]].push(decodeURIComponent(item[1]));
     });
+
     return result;
   };
 


### PR DESCRIPTION
This is a fix for #194 that deals with preserving layers from URLs that contain ampersands. Instead of splitting on `&`, a regex split is used to check for `gist=` and `url=`. The major downside to this method is that the regex will need to be updated if other data types are to be preserved using the URL. 

However, it retains original functionality to support things like `?gist=12345&gist=67890&url=https://foo.com/something=mug&mug=something`