### PR TITLE
Sticky notification

### DIFF
--- a/src/js/dropchop.js
+++ b/src/js/dropchop.js
@@ -38,8 +38,6 @@ var dropchop = (function(dc) {
       dc.util.executeUrlParams();
     }
 
-    dc.util.welcome();
-
   };
 
   dc.boom = function() {

--- a/src/js/layerlist.dropchop.js
+++ b/src/js/layerlist.dropchop.js
@@ -91,7 +91,6 @@ var dropchop = (function(dc) {
           if (check === fromStamp) fromCount = e;
         });
 
-        console.log(toCount, fromCount);
         if (toCount > fromCount) {
           // loop up
           $('.layer-element').each(function(l) {

--- a/src/js/notify.dropchop.js
+++ b/src/js/notify.dropchop.js
@@ -8,11 +8,32 @@ var dropchop = (function(dc) {
       .addClass(type)
       .html(text);
 
-    $(dc.$elem).append(note);
+    // `time` can equal 'close' in order to create a close button
+    if (time === 'close') {
 
-    setTimeout(function() {
-      note.remove();
-    }, time || 3000);
+      var $close = $('<button>').addClass('notification-close')
+        .prop('type', 'button')
+        .html('<i class="fa fa-times"></i>');
+
+      $close.on('click', function(event) {
+        $(this).parent().remove();
+      });
+
+      $(note).append($close);
+      $(dc.$elem).append(note);
+
+    } else {
+
+      $(dc.$elem).append(note);
+
+      setTimeout(function() {
+        note.remove();
+      }, time || 3000);
+
+    }
+
+    
+
   };
 
   return dc;

--- a/src/js/ops.file.dropchop.js
+++ b/src/js/ops.file.dropchop.js
@@ -312,7 +312,6 @@ var dropchop = (function(dc) {
         }
       },
       callback: function(event, name, parameters) {
-        console.log(name, parameters);
         $(dc).trigger('layer:rename', [dc.selection.list[0], parameters[0]]);
       }
     },
@@ -323,7 +322,6 @@ var dropchop = (function(dc) {
       icon: '<i class="fa fa-trash-o"></i>',
       execute: function() {
         $(dc.selection.list).each(function(i) {
-          console.log(this.stamp);
           $(dc).trigger('layer:remove', [this.stamp]);
         });
         dc.selection.clear();

--- a/src/js/ops.geo.dropchop.js
+++ b/src/js/ops.geo.dropchop.js
@@ -334,7 +334,6 @@ var dropchop = (function(dc) {
         }
       ],
       execute: function(params) {
-        console.log(params);
         var result = turf.within.apply(null, params);
         return result;
       }

--- a/src/js/util.dropchop.js
+++ b/src/js/util.dropchop.js
@@ -162,11 +162,11 @@ var dropchop = (function(dc) {
   };
 
   dc.util.welcome = function() {
-    var welcome = '\nWelcome to Dropchop!\n';
-        welcome += 'Once you drop, the chop don\'t stop.\n\n';
-        welcome += 'This project is brought to you by the great people of CUGOS, the Cascadian chapter of OSGeo. If you are ever in Seattle, hit us up\nhello@cugos.org\n\n';
-        welcome += 'You can learn more about this project at dropchop.io/about.';
-    console.log(welcome);
+    // var welcome = '\nWelcome to Dropchop!\n';
+    //     welcome += 'Once you drop, the chop don\'t stop.\n\n';
+    //     welcome += 'This project is brought to you by the great people of CUGOS, the Cascadian chapter of OSGeo. If you are ever in Seattle, hit us up\nhello@cugos.org\n\n';
+    //     welcome += 'You can learn more about this project at dropchop.io/about.';
+    // console.log(welcome);
   };
 
   dc.util.error = function(err) {

--- a/src/js/util.dropchop.js
+++ b/src/js/util.dropchop.js
@@ -161,14 +161,6 @@ var dropchop = (function(dc) {
     }
   };
 
-  dc.util.welcome = function() {
-    // var welcome = '\nWelcome to Dropchop!\n';
-    //     welcome += 'Once you drop, the chop don\'t stop.\n\n';
-    //     welcome += 'This project is brought to you by the great people of CUGOS, the Cascadian chapter of OSGeo. If you are ever in Seattle, hit us up\nhello@cugos.org\n\n';
-    //     welcome += 'You can learn more about this project at dropchop.io/about.';
-    // console.log(welcome);
-  };
-
   dc.util.error = function(err) {
     var error = new Error(err);
     throw error;

--- a/src/scss/_general.scss
+++ b/src/scss/_general.scss
@@ -250,27 +250,6 @@ $geo-button-width: 200px;
   left: $left-menu-width + $width + $geo-button-width;
 }
 
-.notification {
-  float: right;
-  position: relative;
-  z-index: 10;
-  clear: both;
-  padding: 7px;
-  font-size: 0.85em;
-  margin: 5px 5px 0 0;
-  color: white;
-  &.success {
-    background: $green;
-  }
-  &.error {
-    background: $red;
-  }
-  &.info {
-    background: $blue;
-  }
-}
-
-
 .operations-geo {
   position: absolute;
   top: 0;

--- a/src/scss/_notification.scss
+++ b/src/scss/_notification.scss
@@ -1,0 +1,32 @@
+.notification {
+  float: right;
+  position: relative;
+  z-index: 10;
+  clear: both;
+  padding: 12px 15px;
+  font-size: 0.85em;
+  margin: 5px 5px 0 0;
+  color: white;
+  &.success {
+    background: $green;
+  }
+  &.error {
+    background: $red;
+  }
+  &.info {
+    background: $blue;
+  }
+
+  .notification-close {
+    background: transparent;
+    border: none;
+    position: absolute;
+    top: 0;
+    right: 0;
+    color: white;
+    &:hover {
+      background: rgba(255,255,255, 0.2);
+      cursor: pointer;
+    }
+  }
+}

--- a/src/scss/dropchop.scss
+++ b/src/scss/dropchop.scss
@@ -5,5 +5,6 @@
   "general",
   "loader",
   "popup",
-  "attr"
+  "attr",
+  "notification"
 ;

--- a/test/spec/dropchop.spec.js
+++ b/test/spec/dropchop.spec.js
@@ -45,6 +45,16 @@ describe('Dropchop!', function() {
         expect($('.notification').length).to.equal(0);
       }, 300);
     });
+
+    it('notification closes when close button is clicked', function() {
+      dc.init(ops);
+      dc.notify('error', 'some error', 'close');
+
+      expect($('.notification-close').length).to.equal(1);
+
+      $('.notification-close').trigger('click');
+      expect($('.notification-close').length).to.equal(0);
+    });
   });
 
   describe('dropzone.dropchop.js', function() {


### PR DESCRIPTION
This adds an option to `dc.notify()` to the notification system to stick to the page until the user closes it. This should close #193 and get us ready for #188 

Also cleans up some leftover `console.logs` and removes the welcome message because it kept consoling to the tests, which was annoying.