### PR TITLE
Make sure URI updates 

### DIFF
--- a/src/js/layerlist.dropchop.js
+++ b/src/js/layerlist.dropchop.js
@@ -1,5 +1,5 @@
 var dropchop = (function(dc) {
-  
+
   'use strict';
 
   dc = dc || {};
@@ -44,7 +44,7 @@ var dropchop = (function(dc) {
         $(this).removeClass('layer-new');
       });
 
-    
+
     var layerType = $('<span>').addClass('layer-type-image sprite sprite-layer-'+layerTypeIcon(layer.type));
     var checkbox = $('<input>').addClass('layer-toggle').prop({'type': 'checkbox', 'checked': true});
     var remove = $('<button>').addClass('layer-action layer-remove').html('<i class="fa fa-times"></i>');
@@ -55,14 +55,15 @@ var dropchop = (function(dc) {
       $(dc).trigger('layer:duplicate', [$(this).parent().attr('data-stamp')]);
       return false;
     });
-    
+
     remove.on('click', function(event) {
       event.preventDefault();
       $(dc).trigger('layer:remove', [$(this).parent().attr('data-stamp')]);
+      dc.util.updateSearch();
       dc.selection.clear();
       return false;
     });
-    
+
     checkbox.on('change', function(event) {
       if (this.checked) {
         // trigger layer:show
@@ -156,24 +157,24 @@ var dropchop = (function(dc) {
       case 'FeatureCollection':
         icon = 'featurecollection';
         break;
-      case 'Feature<Point>': 
-      case 'Feature<MultiPoint>': 
+      case 'Feature<Point>':
+      case 'Feature<MultiPoint>':
         icon = 'point';
         break;
-      case 'Feature<LineString>': 
-      case 'Feature<MultiLineString>': 
+      case 'Feature<LineString>':
+      case 'Feature<MultiLineString>':
         icon = 'line';
         break;
-      case 'Feature<Polygon>': 
-      case 'Feature<MultiPolygon>': 
+      case 'Feature<Polygon>':
+      case 'Feature<MultiPolygon>':
         icon = 'polygon';
         break;
-      case 'Feature<GeometryCollection>': 
+      case 'Feature<GeometryCollection>':
         icon = 'geom';
         break;
       default:
         icon = 'default';
-        break; 
+        break;
     }
     return icon;
   }

--- a/src/js/layers.dropchop.js
+++ b/src/js/layers.dropchop.js
@@ -19,12 +19,12 @@ var dropchop = (function(dc) {
  * @param {object} file object
  * @param {string} file blob to be converted with JSON.parse()
  */
-  dc.layers.add = function(event, name, blob, type, url) {
+  dc.layers.add = function(event, name, blob, ltype, url) {
     var l = dc.layers.makeLayer(name, blob);
     dc.layers.list[l.stamp] = l;
 
-    if (type && url) {
-      dc.layers.list[l.stamp].type = type;
+    if (ltype && url) {
+      dc.layers.list[l.stamp].ltype = ltype;
       dc.layers.list[l.stamp].url = url;
     }
 
@@ -34,7 +34,7 @@ var dropchop = (function(dc) {
     $(dc).trigger('layer:added', [l]);
 
     // Update URL, if applicable
-    if (type && url) {
+    if (ltype && url) {
       dc.util.updateSearch();
     }
 

--- a/src/js/layers.dropchop.js
+++ b/src/js/layers.dropchop.js
@@ -1,5 +1,5 @@
 var dropchop = (function(dc) {
-  
+
   'use strict';
 
   dc = dc || {};
@@ -19,14 +19,25 @@ var dropchop = (function(dc) {
  * @param {object} file object
  * @param {string} file blob to be converted with JSON.parse()
  */
-  dc.layers.add = function(event, name, blob) {
+  dc.layers.add = function(event, name, blob, type, url) {
     var l = dc.layers.makeLayer(name, blob);
     dc.layers.list[l.stamp] = l;
+
+    if (type && url) {
+      dc.layers.list[l.stamp].type = type;
+      dc.layers.list[l.stamp].url = url;
+    }
 
     dc.notify('success', '<strong>'+l.name+'</strong> has been added!', 3500);
 
     // trigger layer:added
     $(dc).trigger('layer:added', [l]);
+
+    // Update URL, if applicable
+    if (type && url) {
+      dc.util.updateSearch();
+    }
+
   };
 
 /**
@@ -43,7 +54,7 @@ var dropchop = (function(dc) {
       dc.notify('error', 'There was a problem removing the layer.');
       throw err;
     }
-    
+
   };
 
   dc.layers.duplicate = function(event, stamp) {

--- a/src/js/ops.file.dropchop.js
+++ b/src/js/ops.file.dropchop.js
@@ -1,5 +1,5 @@
 var dropchop = (function(dc) {
-  
+
   'use strict';
 
   dc = dc || {};
@@ -22,13 +22,13 @@ var dropchop = (function(dc) {
             var files = this.files;
             $(files).each(function(i) {
               // var ext = dc.util.getFileExtension(files[i].name);
-              
+
               // // if it is a shapefile or zip file
               // if (ext === 'shp' || ext === 'zip') {
               //   // upload a shapefile and add the layer
               //   dc.util.readShpFile
               //   shp("files/pandr").then(function(geojson){
-              //     //do something with your geojson 
+              //     //do something with your geojson
               //   });
               // } else {
                 dc.util.readFile(files[i]);
@@ -66,7 +66,8 @@ var dropchop = (function(dc) {
           var data = JSON.parse(xhr.responseText);
           // get filename based on the end of the url - not sure if this is sustainable
           var name = xhr.responseURL.substring(xhr.responseURL.lastIndexOf('/')+1);
-          $(dc).trigger('file:added', [name, data]);
+          $(dc).trigger('file:added', [name, data, 'url', xhr.responseURL]);
+
         } else {
           dc.notify('error', xhr.status + ': could not retrieve Gist. Please check your URL');
         }
@@ -98,8 +99,9 @@ var dropchop = (function(dc) {
           var data = JSON.parse(xhr.responseText);
           for (var f in data.files) {
             var name = data.files[f].filename;
-            $(dc).trigger('file:added', [name, JSON.parse(data.files[f].content)]);
+            $(dc).trigger('file:added', [name, JSON.parse(data.files[f].content), 'gist', xhr.responseURL.split('/')[xhr.responseURL.split('/').length - 1]]);
           }
+
           // dc.notify('success', 'Succesfully retrieved gist')
         } else {
           dc.notify('error', xhr.status + ': could not retrieve Gist. Please check your URL');
@@ -219,7 +221,7 @@ var dropchop = (function(dc) {
       execute: function() {
         if(!dc.selection.list.length) {
           // extent of entire layer list if nothing selected
-          dc.map.m.fitBounds(dc.map.layergroup.getBounds());  
+          dc.map.m.fitBounds(dc.map.layergroup.getBounds());
         } else {
           // otherwise build the bounds based on selected layers
           var bounds;
@@ -230,7 +232,7 @@ var dropchop = (function(dc) {
           });
           dc.map.m.fitBounds(bounds);
         }
-        
+
       }
     },
 
@@ -306,7 +308,7 @@ var dropchop = (function(dc) {
       ],
       execute: function() {
         if (dc.selection.list.length === 1) {
-          $(dc).trigger('form:file', ['rename']);  
+          $(dc).trigger('form:file', ['rename']);
         } else {
           dc.notify('info', 'Please select <strong>one layer</strong>.');
         }

--- a/src/js/util.dropchop.js
+++ b/src/js/util.dropchop.js
@@ -94,10 +94,10 @@ var dropchop = (function(dc) {
 
     Object.keys(dc.layers.list).forEach(function(layer) {
         /*
-        If a layer has a type and URL (a gist or external GeoJSON link),
-        and we haven't recored this type-url combo already, add it to the
-        unique list. The last check is needed to account for gists with
-        multiple layers.
+        ** If a layer has a type and URL (a gist or external GeoJSON link),
+        ** and we haven't recored this type-url combo already, add it to the
+        ** unique list. The last check is needed to account for gists with
+        ** multiple layers.
         */
         if (dc.layers.list[layer].type && dc.layers.list[layer].url && layers.indexOf(dc.layers.list[layer].type + '=' + dc.layers.list[layer].url) < 0) {
             layers.push(dc.layers.list[layer].type + '=' + dc.layers.list[layer].url);

--- a/src/js/util.dropchop.js
+++ b/src/js/util.dropchop.js
@@ -89,6 +89,31 @@ var dropchop = (function(dc) {
     return result;
   };
 
+  dc.util.updateSearch = function() {
+    var layers = [];
+
+    Object.keys(dc.layers.list).forEach(function(layer) {
+        /*
+        If a layer has a type and URL (a gist or external GeoJSON link),
+        and we haven't recored this type-url combo already, add it to the
+        unique list. The last check is needed to account for gists with
+        multiple layers.
+        */
+        if (dc.layers.list[layer].type && dc.layers.list[layer].url && layers.indexOf(dc.layers.list[layer].type + '=' + dc.layers.list[layer].url) < 0) {
+            layers.push(dc.layers.list[layer].type + '=' + dc.layers.list[layer].url);
+        }
+    });
+
+    var search = layers.length ?  ('?' + layers.join('&')) : '/';
+    console.log('update', search)
+    // Only update the URI if anything has changed
+    if (search !== window.location.search) {
+      console.log('push', search)
+      window.history.pushState(null, null, search);
+    }
+
+  };
+
   dc.util.executeUrlParams = function() {
     var data = dc.util.jsonFromUrl();
 

--- a/src/js/util.dropchop.js
+++ b/src/js/util.dropchop.js
@@ -99,8 +99,8 @@ var dropchop = (function(dc) {
         ** unique list. The last check is needed to account for gists with
         ** multiple layers.
         */
-        if (dc.layers.list[layer].type && dc.layers.list[layer].url && layers.indexOf(dc.layers.list[layer].type + '=' + dc.layers.list[layer].url) < 0) {
-            layers.push(dc.layers.list[layer].type + '=' + dc.layers.list[layer].url);
+        if (dc.layers.list[layer].ltype && dc.layers.list[layer].url && layers.indexOf(dc.layers.list[layer].ltype + '=' + dc.layers.list[layer].url) < 0) {
+            layers.push(dc.layers.list[layer].ltype + '=' + dc.layers.list[layer].url);
         }
     });
 

--- a/src/js/util.dropchop.js
+++ b/src/js/util.dropchop.js
@@ -105,10 +105,9 @@ var dropchop = (function(dc) {
     });
 
     var search = layers.length ?  ('?' + layers.join('&')) : '/';
-    console.log('update', search)
+
     // Only update the URI if anything has changed
     if (search !== window.location.search) {
-      console.log('push', search)
       window.history.pushState(null, null, search);
     }
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,3 +1,27 @@
+if (!Function.prototype.bind) {
+  Function.prototype.bind = function (oThis) {
+    if (typeof this !== "function") {
+      // closest thing possible to the ECMAScript 5 internal IsCallable function
+      throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+    }
+
+    var aArgs = Array.prototype.slice.call(arguments, 1), 
+        fToBind = this, 
+        fNOP = function () {},
+        fBound = function () {
+          return fToBind.apply(this instanceof fNOP && oThis
+                                 ? this
+                                 : oThis,
+                               aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
+
+    fNOP.prototype = this.prototype;
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+}
+
 function getFirstLayerStamp() {
   var stamp;
   for (var l in dc.layers.list) {

--- a/test/spec/util.spec.js
+++ b/test/spec/util.spec.js
@@ -9,6 +9,7 @@ describe('util.dropchop.js', function() {
     document.body.appendChild(dropchopElem);
     dc = dropchop;
     dc.init(ops);
+    dc.layers.list = {};
   });
 
   afterEach(function() {
@@ -77,20 +78,33 @@ describe('util.dropchop.js', function() {
     expect($('body').hasClass('dropchop-loading')).to.equal(true);
     dc.util.loader(false);
     expect($('body').hasClass('dropchop-loading')).to.equal(false);
-  });
+  }); 
 
-  it('dc.util.jsonFromUrl()', function() {
+  it('dc.util.jsonFromUrl()', function(done) {
     var url = '/?url=http://google.com&gist=1234&gist=456&url=http%3A%2F%2Fdropchop.io&url=https://mug.com?cat=booker&fish=truman';
     window.history.pushState(null, null, url);
     expect(dc.util.jsonFromUrl()).to.eql(
-        {
-            url: ['http://google.com', 'http://dropchop.io', 'https://mug.com?cat=booker&fish=truman'],
-            gist: ['1234', '456']
-        }
+      {
+        url: ['http://google.com', 'http://dropchop.io', 'https://mug.com?cat=booker&fish=truman'],
+        gist: ['1234', '456']
+      }
     );
+    done();
   });
 
+  it('dc.util.updateSearch()', function() {
+    var url = '/?gist=333';
+    window.history.pushState(null, null, url);
 
+    expect(window.location.search).to.equal('?gist=333');
+    
+    // adding a new layer should update, and remove the previous since
+    // it doesn't actually exist as a layer
+    dc.layers.add({}, 'new gist', gj, 'gist', '444');
+    expect(window.location.search).to.equal('?gist=444');
 
+    dc.layers.add({}, 'from a url', gj, 'url', 'http://google.com');
+    expect(window.location.search).to.equal('?gist=444&url=http://google.com');
+  });
 
 });


### PR DESCRIPTION
This ensures that the URI updates when layers are added and removed from a gist or URL. 

The main change is that when a layer is added from a gist or URL, the type and URL are passed to the `file:added` event, which then stores those attributes of the layer in `dc.layers.list`. When a layer added or removed, a new function `dc.util.updateSearch` is called which sorts through `dc.layers.list` to find layers that have a `type` and `url`, assembles a new `search`, and pushes it to the URL if it is different from the current one. 

I'm unsure of the best way to write tests for this functionality - anyone have any suggestions?

Also, no idea why my code editor automatically tries to remove whitespace...it makes for these really messy diffs...really sorry about that.

If someone could look this over and test it out that would be great!