### PR TITLE
Nested menus

### DIFF
--- a/src/js/ops.dropchop.js
+++ b/src/js/ops.dropchop.js
@@ -29,9 +29,9 @@ var dropchop = (function(dc) {
     $(dc).on('operation:file:load-overpass', dc.ops.file['load-overpass'].get);
     $(dc).on('operation:file:rename', dc.ops.file.rename.callback);
 
-    var leftMenuSetup = [
+    dc.ops.setup = [
       {
-        name: 'Import',
+        name: 'import',
         icon: '<i class="fa fa-plus"></i>',
         actions: [
           'upload',
@@ -65,10 +65,11 @@ var dropchop = (function(dc) {
 
     // setup ops file
     var leftMenu = $('<div>').addClass('dropchop-menu-left');
+    var setup = dc.ops.setup;
 
-    for (var i = 0; i < leftMenuSetup.length; i++) {
-      var action = leftMenuSetup[i];
-      if (typeof leftMenuSetup[i] !== 'object') {
+    for (var i = 0; i < setup.length; i++) {
+      var action = setup[i];
+      if (typeof setup[i] !== 'object') {
         if(dc.ops.file[action].type === 'break') {
           var $breakSpace = $('<div>').addClass('menu-action-break');
           leftMenu.append($breakSpace);
@@ -80,16 +81,16 @@ var dropchop = (function(dc) {
         // build a collapseable menu "button"
         var collapseBtn = $('<div>')
           .addClass('menu-action menu-collapse')
-          .attr('data-operation', action)
-          .html(leftMenuSetup[i].icon);
+          .html(setup[i].icon);
+        if (setup[i].name === 'import') collapseBtn.addClass('menu-import');
 
         var collapseInner = $('<div>')
           .addClass('menu-collapse-inner');
 
         // loop through each action and build a button for it, just like above,
         // but append it to the menu-collapse-inner element
-        for (var a = 0; a < leftMenuSetup[i].actions.length; a++) {
-          var actn = leftMenuSetup[i].actions[a];
+        for (var a = 0; a < setup[i].actions.length; a++) {
+          var actn = dc.ops.setup[i].actions[a];
           collapseInner.append(buildMenuButton(actn));
         }
         collapseBtn.append(collapseInner);

--- a/src/js/ops.dropchop.js
+++ b/src/js/ops.dropchop.js
@@ -29,23 +29,86 @@ var dropchop = (function(dc) {
     $(dc).on('operation:file:load-overpass', dc.ops.file['load-overpass'].get);
     $(dc).on('operation:file:rename', dc.ops.file.rename.callback);
 
+    var leftMenuSetup = [
+      {
+        name: 'Import',
+        icon: '<i class="fa fa-plus"></i>',
+        actions: [
+          'upload',
+          'load-url',
+          'load-gist',
+          'load-overpass',
+          'location'
+        ]
+      },
+      {
+        name: 'Save',
+        icon: '<i class="fa fa-floppy-o"></i>',
+        actions: [
+          'save-geojson',
+          'save-shapefile'
+        ]
+      },
+      {
+        name: 'Geo Actions',
+        icon: '<i class="fa fa-wrench"></i>',
+        actions: [
+          'extent',
+          'expand',
+          'combine',
+          'rename',
+          'remove',
+        ]
+      },      
+      'info'
+    ];
+
     // setup ops file
     var leftMenu = $('<div>').addClass('dropchop-menu-left');
-    for (var fileOp in dc.ops.file) {
-      if(dc.ops.file[fileOp].type === 'break') {
-        var $breakSpace = $('<div>').addClass('menu-action-break');
-        leftMenu.append($breakSpace);
+
+    for (var i = 0; i < leftMenuSetup.length; i++) {
+      var action = leftMenuSetup[i];
+      if (typeof leftMenuSetup[i] !== 'object') {
+        if(dc.ops.file[action].type === 'break') {
+          var $breakSpace = $('<div>').addClass('menu-action-break');
+          leftMenu.append($breakSpace);
+        } else {
+          leftMenu.append(buildMenuButton(action));
+        }
+
       } else {
-        var fileBtn = $('<button>').addClass('menu-action')
-          .html(dc.ops.file[fileOp].icon || 'A')
-          .attr('data-operation', fileOp)
-          .attr('data-tooltip', dc.ops.file[fileOp].description);
-          if (dc.ops.file[fileOp].type === 'info') fileBtn.addClass('dropchop-info');
-        fileBtn.on('click', _fileBtnClick);
-        leftMenu.append(fileBtn);
+        // build a collapseable menu "button"
+        var collapseBtn = $('<div>')
+          .addClass('menu-action menu-collapse')
+          .attr('data-operation', action)
+          .html(leftMenuSetup[i].icon);
+
+        var collapseInner = $('<div>')
+          .addClass('menu-collapse-inner');
+
+        // loop through each action and build a button for it, just like above,
+        // but append it to the menu-collapse-inner element
+        for (var a = 0; a < leftMenuSetup[i].actions.length; a++) {
+          var actn = leftMenuSetup[i].actions[a];
+          collapseInner.append(buildMenuButton(actn));
+        }
+        collapseBtn.append(collapseInner);
+
+        // append the entire collapseBtn to the leftMenu
+        leftMenu.append(collapseBtn);
       }
     }
     dc.$elem.append(leftMenu);
+
+    function buildMenuButton(action) {
+      var button = $('<button>').addClass('menu-action')
+        .html(dc.ops.file[action].icon || '!')
+        .attr('data-operation', action)
+        .attr('data-tooltip', dc.ops.file[action].description);
+        if (dc.ops.file[action].type === 'info') button.addClass('dropchop-info');
+      button.on('click', _fileBtnClick);
+      return button;
+    }
   };
 
   /* jshint ignore:start */

--- a/src/js/ops.file.dropchop.js
+++ b/src/js/ops.file.dropchop.js
@@ -6,12 +6,6 @@ var dropchop = (function(dc) {
   dc.ops = dc.ops || {};
 
   dc.ops.file = {
-    // imports: {
-    //   type: 'collapse',
-    //   icon: '<i class="fa fa-plus"></i>',
-    //   description: 'Import data',
-    //   actions: [],
-    // },
     upload: {
       description: 'Upload from your computer (.geojson)',
       icon: '<i class="fa fa-upload"></i>',
@@ -161,8 +155,6 @@ var dropchop = (function(dc) {
       }
     },
 
-    'break1': { type: 'break' },
-
     'save-geojson': {
       minFeatures: 1,
       description: 'Save as GeoJSON',
@@ -203,8 +195,6 @@ var dropchop = (function(dc) {
       },
       createsLayer: false
     },
-
-    'break2': { type: 'break' },
 
     extent: {
       minFeatures: 1,
@@ -284,8 +274,6 @@ var dropchop = (function(dc) {
     //     dc.attr.render(dc.selection.list[0]);
     //   }
     // },
-
-    'break3': { type: 'break' },
 
     rename: {
       minFeatures: 1,

--- a/src/js/ops.file.dropchop.js
+++ b/src/js/ops.file.dropchop.js
@@ -6,6 +6,12 @@ var dropchop = (function(dc) {
   dc.ops = dc.ops || {};
 
   dc.ops.file = {
+    // imports: {
+    //   type: 'collapse',
+    //   icon: '<i class="fa fa-plus"></i>',
+    //   description: 'Import data',
+    //   actions: [],
+    // },
     upload: {
       description: 'Upload from your computer (.geojson)',
       icon: '<i class="fa fa-upload"></i>',
@@ -21,19 +27,7 @@ var dropchop = (function(dc) {
           .on('change', function() {
             var files = this.files;
             $(files).each(function(i) {
-              // var ext = dc.util.getFileExtension(files[i].name);
-              
-              // // if it is a shapefile or zip file
-              // if (ext === 'shp' || ext === 'zip') {
-              //   // upload a shapefile and add the layer
-              //   dc.util.readShpFile
-              //   shp("files/pandr").then(function(geojson){
-              //     //do something with your geojson 
-              //   });
-              // } else {
-                dc.util.readFile(files[i]);
-              // }
-
+              dc.util.readFile(files[i]);
             });
             $blindInput.remove();
           });

--- a/src/scss/_left.menu.scss
+++ b/src/scss/_left.menu.scss
@@ -66,5 +66,37 @@
         background: darken($fuscia, 10);
       }
     }
+
+    &.menu-collapse {
+      .menu-collapse-inner {
+        display: none;
+        box-shadow: 0 0 4px 0 rgba(0,0,0,0.4);
+        z-index: 10;
+        .menu-action {
+          margin: 0;
+          border-top: 1px solid #e5e5e5;
+          &:first-child {
+            border: none;
+          }
+        }
+      }
+      &:hover {
+        background: $grey;
+        &:before,
+        &:after {
+          content: "";
+          background: transparent;
+          border: none;
+          visibility: hidden;
+          display: none;
+        }
+        .menu-collapse-inner {
+          display: block;
+          position: absolute;
+          left: 40px;
+          top: 0;
+        }
+      }
+    }
   }
 }

--- a/src/scss/_left.menu.scss
+++ b/src/scss/_left.menu.scss
@@ -66,6 +66,10 @@
         background: darken($fuscia, 10);
       }
     }
+    &.menu-import {
+      background: $green;
+      color: white;
+    }
 
     &.menu-collapse {
       .menu-collapse-inner {

--- a/test/spec/dropchop.spec.js
+++ b/test/spec/dropchop.spec.js
@@ -67,4 +67,16 @@ describe('Dropchop!', function() {
     });
   });
 
+  describe('left menu', function() {
+    it('order is accurate', function() {
+      dc.init(ops);
+      if (typeof dc.ops.setup[0] === 'object') {
+        expect($('.menu-action:first-child').hasClass('menu-collapse')).to.equal(true);
+      } else {
+        var op = $('.menu-action:first-child').attr('data-operation');
+        expect(op).to.equal(dc.ops.setup[0]);
+      }
+    });
+  });
+
 });


### PR DESCRIPTION
This builds in the ability to make the left menu space have collapsable menus in order to preserve real-estate as we create more and more options.

A relatively major difference is that the menu is now built from a `setup` object in `dc.ops.setup` instead of looping through the `dc.ops.file.OPERATION` objects. This menu setup, located [here](https://github.com/cugos/dropchop/compare/nested-menus?expand=1#diff-1454db8304b25cb3d6b99183c0f18697R32) gives us the option to either throw in direct operations (as strings) or objects with actions, which turn into nested menus when you hover over them. Here's what it looks like:

![dropchop-collapseablemenu](https://cloud.githubusercontent.com/assets/1943001/10712450/865e2b84-7a50-11e5-829a-2e61925a13cd.gif)

This should fix #197 for the time being.