### PR TITLE
Add some error handling to shapefile loading

### DIFF
--- a/src/js/util.dropchop.js
+++ b/src/js/util.dropchop.js
@@ -46,10 +46,18 @@ var dropchop = (function(dc) {
       reader.readAsArrayBuffer(file);
       dc.util.loader(true);
       reader.onloadend = function(event) {
-        shp(reader.result).then(function(geojson) {
-          dc.util.loader(false);
-          $(dc).trigger('file:added', [geojson.fileName, geojson]);
-        });
+        shp(reader.result)
+          .catch(function(error) {
+            console.log("Problematic projection - ", error);
+          })
+          .then(function(geojson) {
+            dc.util.loader(false);
+            if (!geojson) {
+              return dc.notify('error', 'Invalid projection or shapefile.', 2500);
+            }
+
+            $(dc).trigger('file:added', [geojson.fileName, geojson]);
+          });
       };
     } else {
       reader.readAsText(file, 'UTF-8');


### PR DESCRIPTION
A band aid for #206. Apparently shapefile-js doesn't automatically handle *all* projections, just a lot of common ones. I added some error handling so that if the projection isn't recognized an error is thrown.
