### PR TITLE
TopoJSON

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,6 +38,7 @@ var vendorJS = [
   './node_modules/browser-filesaver/FileSaver.js',
   './node_modules/shp-write/shpwrite.js',
   './node_modules/shpjs/dist/shp.min.js',
+  './node_modules/topojson/topojson.min.js',
   './src/lib/shp-2-geojson.js',
   './node_modules/osmtogeojson/osmtogeojson.js',
   './node_modules/turf/turf.js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,9 @@ var jshint = require('gulp-jshint');
 var ghPages = require('gulp-gh-pages');
 var Server = require('karma').Server;
 var file = require('gulp-file');
+var browserify = require('browserify');
+var source = require('vinyl-source-stream');
+var buffer = require('vinyl-buffer');
 
 
 gulp.task('sass', function(){
@@ -38,12 +41,13 @@ var vendorJS = [
   './node_modules/browser-filesaver/FileSaver.js',
   './node_modules/shp-write/shpwrite.js',
   './node_modules/shpjs/dist/shp.min.js',
-  './node_modules/topojson/topojson.min.js',
   './src/lib/shp-2-geojson.js',
   './node_modules/osmtogeojson/osmtogeojson.js',
   './node_modules/turf/turf.js',
+  './dist/static/js/topojson_package.js',
   './lib/mapbox.js/mapbox.js'
 ];
+
 
 gulp.task('lint', function() {
   return gulp.src('./src/js/**/*.js')
@@ -60,7 +64,16 @@ gulp.task('js_dropchop', function() {
     .pipe(gulp.dest('./dist/static/js'));
 });
 
-gulp.task('js_vendor', function() {
+gulp.task('topojson', function() {
+  return browserify(['./lib/topojson_setup.js'])
+    .bundle()
+    .pipe(source('topojson_package.js'))
+    .pipe(buffer())
+    .pipe(uglify())
+    .pipe(gulp.dest('./dist/static/js/'));
+});
+
+gulp.task('js_vendor', ['topojson'], function() {
   return gulp.src(vendorJS)
     .pipe(sourcemap.init())
     .pipe(concat('vendor.js'))

--- a/lib/topojson_setup.js
+++ b/lib/topojson_setup.js
@@ -1,3 +1,5 @@
+window.Float64Array = require('typedarray').Float64Array;
+
 window.topojson = {
   topology: require('../node_modules/topojson/lib/topojson/topology'),
   client: require('../node_modules/topojson/topojson.js')

--- a/lib/topojson_setup.js
+++ b/lib/topojson_setup.js
@@ -1,0 +1,4 @@
+window.topojson = {
+  topology: require('../node_modules/topojson/lib/topojson/topology'),
+  client: require('../node_modules/topojson/topojson.js')
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "turf": "^2.0.2"
   },
   "devDependencies": {
+    "browserify": "^11.2.0",
     "chai": "^3.2.0",
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",
@@ -46,6 +47,8 @@
     "karma-sinon": "^1.0.4",
     "mocha": "^2.3.0",
     "phantomjs": "^1.9.18",
-    "sinon": "^1.16.1"
+    "sinon": "^1.16.1",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "shpjs": "^3.2.1",
     "tablesort": "^3.1.0",
     "topojson": "^1.6.19",
-    "turf": "^2.0.2"
+    "turf": "^2.0.2",
+    "typedarray": "0.0.6"
   },
   "devDependencies": {
     "browserify": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "shp-write": "^0.2.4",
     "shpjs": "^3.2.1",
     "tablesort": "^3.1.0",
+    "topojson": "^1.6.19",
     "turf": "^2.0.2"
   },
   "devDependencies": {

--- a/src/js/layers.dropchop.js
+++ b/src/js/layers.dropchop.js
@@ -22,7 +22,7 @@ var dropchop = (function(dc) {
 
   dc.layers.add = function(event, name, blob, ltype, url) {
     if (blob.type === "Topology") {
-      blob = topojson.feature(blob, blob.objects[Object.keys(blob.objects)[0]]);
+      blob = topojson.client.feature(blob, blob.objects[Object.keys(blob.objects)[0]]);
     }
 
     var l = dc.layers.makeLayer(name, blob);

--- a/src/js/layers.dropchop.js
+++ b/src/js/layers.dropchop.js
@@ -1,5 +1,5 @@
 var dropchop = (function(dc) {
-  
+
   'use strict';
 
   dc = dc || {};
@@ -20,6 +20,10 @@ var dropchop = (function(dc) {
  * @param {string} file blob to be converted with JSON.parse()
  */
   dc.layers.add = function(event, name, blob) {
+    if (blob.type === "Topology") {
+        blob = topojson.feature(blob, blob.objects[Object.keys(blob.objects)[0]]);
+    }
+
     var l = dc.layers.makeLayer(name, blob);
     dc.layers.list[l.stamp] = l;
 
@@ -43,7 +47,7 @@ var dropchop = (function(dc) {
       dc.notify('error', 'There was a problem removing the layer.');
       throw err;
     }
-    
+
   };
 
   dc.layers.duplicate = function(event, stamp) {

--- a/src/js/ops.dropchop.js
+++ b/src/js/ops.dropchop.js
@@ -1,5 +1,5 @@
 var dropchop = (function(dc) {
-  
+
   'use strict';
 
   dc = dc || {};
@@ -46,6 +46,7 @@ var dropchop = (function(dc) {
         icon: '<i class="fa fa-floppy-o"></i>',
         actions: [
           'save-geojson',
+          'save-topojson',
           'save-shapefile'
         ]
       },
@@ -59,7 +60,7 @@ var dropchop = (function(dc) {
           'rename',
           'remove',
         ]
-      },      
+      },
       'info'
     ];
 
@@ -187,7 +188,7 @@ var dropchop = (function(dc) {
 
     // create name array
     data.name = dc.util.concat(nameArray, '_', operation);
-    
+
     return data;
   };
 
@@ -227,7 +228,7 @@ var dropchop = (function(dc) {
       btn.removeClass('operation-inactive');
       btn.prop('disabled', false);
     }
-    
+
   };
 
   return dc;

--- a/src/js/ops.file.dropchop.js
+++ b/src/js/ops.file.dropchop.js
@@ -173,6 +173,29 @@ var dropchop = (function(dc) {
       }
     },
 
+    'save-topojson': {
+      minFeatures: 1,
+      description: 'Save as TopoJSON',
+      icon: '<i class="fa fa-object-ungroup"></i>',
+      createsLayer: false,
+      execute: function() {
+        for (var i = 0; i < dc.selection.list.length; i++) {
+          var content = JSON.stringify(
+            topojson.topology({
+              collection: dc.selection.list[i].raw
+            }, {
+              'property-transform': function(feature) {
+                return feature.properties;
+            }})
+          );
+          var title = 'dropchop_' + dc.selection.list[i].name + '.topojson';
+          saveAs(new Blob([content], {
+            type: 'text/plain;charset=utf-8'
+          }), title);
+        }
+      }
+    },
+
     'save-shapefile': {
       minFeatures: 1,
       description: 'Save as Shapefile',

--- a/src/js/util.dropchop.js
+++ b/src/js/util.dropchop.js
@@ -42,7 +42,7 @@ var dropchop = (function(dc) {
   dc.util.readFile = function(file) {
     var reader = new FileReader();
     // if a zipfile, assume shapefile for now
-    if (file.name.indexOf('.zip') > -1 || file.name.indexOf('.shp') > -1) {
+    if (file.name.indexOf('.zip') > -1) {
       reader.readAsArrayBuffer(file);
       dc.util.loader(true);
       reader.onloadend = function(event) {


### PR DESCRIPTION
Added the ability to add and export TopoJSON as outlined in #201. The main changes are as follows:

**Front**
+ Added a button to the `save` menu to save as TopoJSON
+ Added ability to add a TopoJSON file by dragging and dropping, from a gist, or from a URL

**Back**
+ Added a new dependency - `topojson`
+ Added three new dev dependencies - `browserify`, `vinyl-source-stream`, and `vinyl-buffer`
+ In order to use the server API on the client side for saving to TopoJSON, a new script was added `lib/topojson_setup.js` that creates a global object for both the client and server API. However, for now only the `topology` function from the server API was added so that unnecessary methods are not included. It is then run through `browserify` and included in `vendor.js`.

It'd be nice to add tests as well, but it seems like there are not currently tests for this part of DC (though perhaps there should be?). Thoughts?

