### PR TITLE
Sort available turf functions when layer is selected. Closes #207.

### DIFF
--- a/src/js/ops.dropchop.js
+++ b/src/js/ops.dropchop.js
@@ -142,7 +142,30 @@ var dropchop = (function(dc) {
       throw err;
     }
   }
+
   /* jshint ignore:end */
+
+  // Sort turf operations by availablility and alphabetically
+  function _sortGeo() {
+
+    // Get all of the turf buttons and sort them alphabetically
+    var alpha = $('.operation-geo').sort(function(a, b) {
+      return ($(b).data('operation') < $(a).data('operation')) ? 1 : -1;
+    });
+
+    // Grab all the active buttons and reappend them
+    alpha.filter(function(i, d) {
+      if (!($(d).prop('disabled'))) { return d }
+    }).appendTo('.operations-geo');
+
+    // Grab all the inactive buttons and reappend them
+    alpha.filter(function(i, d) {
+      if ($(d).prop('disabled')) { return d }
+    }).appendTo('.operations-geo');
+
+    // Scroll to the top to keep things nice
+    $('.operations-geo').scrollTop(0);
+  }
 
   /**
    * Execute a turf function based on button operation click.
@@ -229,6 +252,8 @@ var dropchop = (function(dc) {
       btn.prop('disabled', false);
     }
 
+    // Sort the list
+    _sortGeo();
   };
 
   return dc;


### PR DESCRIPTION
So jQuery. Much wow.

Per #207, sort the available geometry functions by availability and alphabetically when a layer is selected. Added a function `_sortGeo` that does the sorting by selecting the buttons and sorting them all alphabetically, then reattaching the active functions followed by the inactive ones. 

If we were to ever add underscore as dependency this could be cleaned up by using a chained `_.sortBy`. Also, there is probably a fancy sorting function you could write to do this all at once, but alas, after playing with a bunch of convoluted methods this worked best and I think is easy to read. 