### PR TITLE
Double-click to zoom (fixes #205)

### DIFF
--- a/src/js/layerlist.dropchop.js
+++ b/src/js/layerlist.dropchop.js
@@ -116,6 +116,10 @@ var dropchop = (function(dc) {
       }
     });
 
+    layerDiv.on('dblclick', function(event) {
+      dc.ops.file.extent.execute();
+    });
+
     layerlistItem.append(layerDiv);
     layerlistItem.append(checkbox);
     layerlistItem.append(layerType);


### PR DESCRIPTION
This was a super easy add but really feels natural to me.  Nice when touring layers, trying to figure out which was which.

![double-click-zoom](https://cloud.githubusercontent.com/assets/897290/10874881/a461248a-80e8-11e5-84e7-45eec281f861.gif)
