### PR TITLE
Add keyboard shortcuts

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,18 +36,20 @@ gulp.task('mapbox_assets', function() {
 });
 
 var vendorJS = [
+  // General Utils
   './node_modules/jquery/dist/jquery.js',
   './node_modules/browser-filesaver/FileSaver.js',
+  './node_modules/mousetrap/mousetrap.js',
+
+  // Geo Tools
+  './dist/static/js/topojson_package.js',
+  './lib/mapbox.js/mapbox.js',
+  './node_modules/esri2geo/esri2geo.js',
+  './node_modules/osmtogeojson/osmtogeojson.js',
   './node_modules/shp-write/shpwrite.js',
   './node_modules/shpjs/dist/shp.min.js',
-  './src/lib/shp-2-geojson.js',
-  './node_modules/osmtogeojson/osmtogeojson.js',
   './node_modules/turf/turf.js',
-  './node_modules/esri2geo/esri2geo.js',
-  './dist/static/js/topojson_package.js',
-  './lib/mapbox.js/mapbox.js'
-
-
+  './src/lib/shp-2-geojson.js'
 ];
 
 gulp.task('lint', function() {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "geoglyphs": "0.0.10",
     "jquery": "^2.1.4",
     "js-polyfills": "^0.1.12",
+    "mousetrap": "^1.5.3",
     "osmtogeojson": "^2.2.5",
     "shp-write": "^0.2.4",
     "shpjs": "^3.2.1",

--- a/src/js/dropchop.js
+++ b/src/js/dropchop.js
@@ -35,6 +35,9 @@ var dropchop = (function(dc) {
     // setup forms
     dc.form.init();
 
+    // setup keyboard shortcuts
+    dc.shortcuts.init();
+
     // get URL information if it exists
     if(location.search.length) {
       dc.util.executeUrlParams();

--- a/src/js/layerlist.dropchop.js
+++ b/src/js/layerlist.dropchop.js
@@ -159,6 +159,49 @@ var dropchop = (function(dc) {
   dc.layerlist.clearSelection = function($item, lyr) {
     dc.selection.clear();
   };
+  dc.layerlist.selectAll = function() {
+    $('.layer-element').each(function(l) {
+      dc.layerlist.selectLayer($(this).find('.layer-name'), dc.layers.list[$(this).attr('data-stamp')]);
+    });
+  };
+  dc.layerlist.checkAll = function(mustBeSelected) {
+    for (var i in dc.layers.list) {
+      var layer = dc.layers.list[i];
+      if (mustBeSelected && !dropchop.selection.isSelected(layer)) {
+        continue;
+      }
+      elemToggle(dc.layers.list[i].stamp, true);
+    }
+  };
+  dc.layerlist.uncheckAll = function(mustBeSelected) {
+    for (var i in dc.layers.list) {
+      var layer = dc.layers.list[i];
+      if (mustBeSelected && !dropchop.selection.isSelected(layer)) {
+        continue;
+      }
+      elemToggle(layer.stamp, false);
+    }
+  };
+  dc.layerlist.toggleAll = function(event) {
+    if ($(this).find('input').prop('checked')) {
+      dc.layerlist.uncheckAll();
+    } else {
+      dc.layerlist.checkAll();
+    }
+  };
+  dc.layerlist.removeLayerListItem = function(event, stamp) {
+    $('[data-stamp='+stamp+']').fadeOut(300, function() {
+      $(this).remove();
+      delete dc.layerlist.elems[stamp];
+
+      // show helper text if no layers exist
+      // this has to check inside since there is a 300 ms delay with the fade
+      if ($('.layer-element').length === 0) {
+        $('.layer-help').show();
+        $('.layer-toggleAll').hide();
+      }
+    });
+  };
 
   function layerTypeIcon(type) {
     var icon;
@@ -188,40 +231,12 @@ var dropchop = (function(dc) {
     return icon;
   }
 
-  dc.layerlist.toggleAll = function(event) {
-    // turn them on
-    if ($(this).find('input').prop('checked')) {
-      for (var i in dc.layers.list) {
-        elemToggle(dc.layers.list[i].stamp, true);
-      }
-    // turn them off
-    } else {
-      for (var o in dc.layers.list) {
-        elemToggle(dc.layers.list[o].stamp, false);
-      }
-    }
-
-    function elemToggle(stamp, bool) {
-      $('.layer-element[data-stamp='+stamp+']')
-        .find('.layer-toggle')
-        .prop('checked', bool)
-        .trigger('change'); // sets off a chain reaction
-    }
-  };
-
-  dc.layerlist.removeLayerListItem = function(event, stamp) {
-    $('[data-stamp='+stamp+']').fadeOut(300, function() {
-      $(this).remove();
-      delete dc.layerlist.elems[stamp];
-
-      // show helper text if no layers exist
-      // this has to check inside since there is a 300 ms delay with the fade
-      if ($('.layer-element').length === 0) {
-        $('.layer-help').show();
-        $('.layer-toggleAll').hide();
-      }
-    });
-  };
+  function elemToggle(stamp, bool) {
+    $('.layer-element[data-stamp='+stamp+']')
+      .find('.layer-toggle')
+      .prop('checked', bool)
+      .trigger('change'); // sets off a chain reaction
+  }
 
   return dc;
 

--- a/src/js/layers.dropchop.js
+++ b/src/js/layers.dropchop.js
@@ -23,7 +23,7 @@ var dropchop = (function(dc) {
     if (blob.type === "Topology") {
       blob = topojson.client.feature(blob, blob.objects[Object.keys(blob.objects)[0]]);
     }
-    
+
     var l = dc.layers.makeLayer(name, blob);
     dc.layers.list[l.stamp] = l;
 
@@ -58,7 +58,6 @@ var dropchop = (function(dc) {
       dc.notify('error', 'There was a problem removing the layer.');
       throw err;
     }
-
   };
 
   dc.layers.duplicate = function(event, stamp) {

--- a/src/js/menus.layer-context-menu.dropchop.js
+++ b/src/js/menus.layer-context-menu.dropchop.js
@@ -27,13 +27,13 @@ var dropchop = (function(dc) {
     var lyrData = dc.layers.list[layer.attr('data-stamp')];
 
     // Select layer if unselected
-    if (!Boolean(dropchop.selection.list.indexOf(lyrData) + 1)) {
+    if (!(dropchop.selection.isSelected(lyrData))) {
       $layerNameDiv.trigger('click');
     }
 
     // create left-click context-menu
     var menu = $('<div>').addClass('context-menu');
-    
+
     var menuList = $('<ul>');
     menu.append(menuList);
 

--- a/src/js/selection.dropchop.js
+++ b/src/js/selection.dropchop.js
@@ -1,9 +1,9 @@
 var dropchop = (function(dc) {
-  
+
   'use strict';
 
   dc = dc || {};
-  
+
   dc.selection = {};
   dc.selection.list = [];
 
@@ -32,6 +32,10 @@ var dropchop = (function(dc) {
     $('.operation-geo').addClass('operation-inactive');
     $('.operation-geo').prop('disabled', true);
     dc.selection.list = [];
+  };
+
+  dc.selection.isSelected = function(lyrData) {
+    return Boolean(dropchop.selection.list.indexOf(lyrData) + 1);
   };
 
   function _layerRemoved(event, stamp) {

--- a/src/js/shortcuts.dropchop.js
+++ b/src/js/shortcuts.dropchop.js
@@ -1,0 +1,44 @@
+var dropchop = (function(dc) {
+
+  'use strict';
+
+  dc = dc || {};
+
+  dc.shortcuts = {};
+  dc.shortcuts.list = [];
+
+  dc.shortcuts.init = function() {
+    // Select All
+    Mousetrap.bind(['command+a', 'ctrl+a'], function(e) {
+      dc.layerlist.selectAll();
+      return false;
+    });
+
+    // Clear Selection
+    Mousetrap.bind(['command+backspace', 'ctrl+backspace'], function(e) {
+      dc.layerlist.clearSelection();
+      return false;
+    });
+
+    // Delete Selected Layers
+    Mousetrap.bind(['ctrl+shift+k'], function(e) {
+      dc.ops.file.remove.execute();
+      return false;
+    });
+
+    // Uncheck Layer Visibility
+    Mousetrap.bind(['command+plus', 'ctrl+plus', 'command+=', 'ctrl+='], function(e) {
+      dropchop.layerlist.checkAll(true);
+      return false;
+    });
+
+    // Check Layer Visibility
+    Mousetrap.bind(['command+-', 'ctrl+-'], function(e) {
+      dc.layerlist.uncheckAll(true);
+      return false;
+    });
+  };
+  return dc;
+
+
+})(dropchop || {});


### PR DESCRIPTION
Took a shot at adding some keyboard shortcuts for the layerlist.

![keyboard-shortcuts](https://cloud.githubusercontent.com/assets/897290/11019044/d32323ae-85a2-11e5-8e49-9791d4d3d259.gif)

Basically:

`cmd` + `a` / `ctrl` + `a`: Select All
`cmd` + `bkspc` / `ctrl` + `bkspc`: Deselect All
`cmd` + `+` / `ctrl` + `+`: Check All
`cmd` + `-` / `ctrl` + `-`: Uncheck All
`ctrl` + `shift` + `k`: Delete selected layers