### PR TITLE
use overpass-wizard to generate Overpass API queries

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,9 @@ var vendorJS = [
   './node_modules/shp-write/shpwrite.js',
   './node_modules/shpjs/dist/shp.min.js',
   './node_modules/turf/turf.js',
-  './src/lib/shp-2-geojson.js'
+  './src/lib/shp-2-geojson.js',
+  './dist/static/js/overpass-wizard.js',
+  './dist/static/js/overpass-wizard-expand.js'
 ];
 
 gulp.task('lint', function() {
@@ -76,7 +78,22 @@ gulp.task('topojson', function() {
     .pipe(gulp.dest('./dist/static/js/'));
 });
 
-gulp.task('js_vendor', ['topojson'], function() {
+gulp.task('overpass-wizard', function() {
+  browserify(['./node_modules/overpass-wizard/index.js'], {standalone: "overpass-wizard"})
+    .bundle()
+    .pipe(source('overpass-wizard.js'))
+    .pipe(buffer())
+    .pipe(uglify())
+    .pipe(gulp.dest('./dist/static/js/'));
+  browserify(['./node_modules/overpass-wizard/expand.js'], {standalone: "overpass-wizard-expand"})
+    .bundle()
+    .pipe(source('overpass-wizard-expand.js'))
+    .pipe(buffer())
+    .pipe(uglify())
+    .pipe(gulp.dest('./dist/static/js/'));
+});
+
+gulp.task('js_vendor', ['topojson', 'overpass-wizard'], function() {
   return gulp.src(vendorJS)
     .pipe(sourcemap.init())
     .pipe(concat('vendor.js'))

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "js-polyfills": "^0.1.12",
     "mousetrap": "^1.5.3",
     "osmtogeojson": "^2.2.5",
+    "overpass-wizard": "0.0.4",
     "shp-write": "^0.2.4",
     "shpjs": "^3.2.1",
     "tablesort": "^3.1.0",

--- a/src/js/ops.file.dropchop.js
+++ b/src/js/ops.file.dropchop.js
@@ -186,7 +186,7 @@ var dropchop = (function(dc) {
       parameters: [
         {
           name: 'query',
-          description :'Learn more about <a href="http://wiki.openstreetmap.org/wiki/Overpass_API/Language_Guide" target="_blank">the query language</a>.',
+          description :'Enter a search query in the overpass-turbo wizard syntax. Learn more about <a href="http://wiki.openstreetmap.org/wiki/Overpass_turbo/Wizard" target="_blank">the supported features</a>.',
           type: 'text',
           default: 'amenity=bar'
         },
@@ -206,7 +206,14 @@ var dropchop = (function(dc) {
 
         // build the query with bounding box
         var bbox = dc.util.getBBox();
-        dc.util.xhr('http://overpass-api.de/api/interpreter?[out:json];node['+parameters[0]+']('+bbox+');out;', dc.ops.file['load-overpass'].callback);
+        var overpassQuery = overpassWizard(parameters[0]);
+        if (overpassQuery === false)
+          return dc.notify('error', 'Can\'t create overpass query for this search input.');
+        overpassWizardExpand(overpassQuery, bbox, function(err, expandedOverpassQuery) {
+          if (err)
+            return dc.notify('error', 'Error while expanding overpass query: ' + err);
+          dc.util.xhr('http://overpass-api.de/api/interpreter?data='+encodeURIComponent(expandedOverpassQuery), dc.ops.file['load-overpass'].callback);
+        });
       },
       callback: function(xhr, xhrEvent) {
         dropchop.util.loader(false);


### PR DESCRIPTION
This enables a human friendly syntax to query for almost arbitrary overpass queries. A few examples:
* amenity=bar in "New York City"
* building=*
* type:relation and route=bicycle