### PR TITLE
toggleLayers update

### DIFF
--- a/lib/topojson_setup.js
+++ b/lib/topojson_setup.js
@@ -1,4 +1,4 @@
 window.topojson = {
   topology: require('../node_modules/topojson/lib/topojson/topology'),
-  client: require('../node_modules/topojson/topojson.js')
+  client: require('../node_modules/topojson/build/topojson.js')
 }

--- a/src/js/layerlist.dropchop.js
+++ b/src/js/layerlist.dropchop.js
@@ -22,7 +22,7 @@ var dropchop = (function(dc) {
     dc.layerlist.$elem.append(liHelper);
 
     var toggleLayers = $('<li>').addClass('layer-toggleAll')
-      .html('<label><input type="checkbox" checked>Toggle all layers</label>');
+      .html('<label><input id="allCheckboxes" type="checkbox" checked>Toggle all layers</label>');
     toggleLayers.on('change', dc.layerlist.toggleAll);
     dc.layerlist.$elem.append(toggleLayers);
 
@@ -183,10 +183,10 @@ var dropchop = (function(dc) {
     }
   };
   dc.layerlist.toggleAll = function(event) {
-    if ($(this).find('input').prop('checked')) {
-      dc.layerlist.uncheckAll();
-    } else {
+    if (document.getElementById('allCheckboxes').checked) {
       dc.layerlist.checkAll();
+    } else {
+      dc.layerlist.uncheckAll();
     }
   };
   dc.layerlist.removeLayerListItem = function(event, stamp) {


### PR DESCRIPTION
The 'Toggle all layers' checkbox actually runs counter to how it should. On initial load, if we have layers loaded from the hash, the first 'uncheck' of that checkbox actually does nothing. The jquery checks that were being run in the 'dc.layerlist.toggleAll' worked after that, but since the initial 'loaded' property on the 'Toggle all layers' input was now gone, the toggleAll checkbox would actually be checked when the map layers were hidden, and unchecked when they were displayed.
For this particular use case, document.getElementById is actually a safer bet, hence the new 'allCheckboxes' id.

I also updated the topojson path because it failed on our 'js_vendor' gulp task. 