### PR TITLE
Turf v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.2.2
+
+* Upgrade to turf.js v3.0 (specifically 3.0.14)
+* Update `CONTRIBUTING.md` to reflect new `src/js` structure
+
 ### 0.2.1
 
 * Create `window.onbeforeunload` to prevent from navigating away from the page. This isn't a "smart" unload function, in that it does not look for "changes" or "saves".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Turf functions are their own geoprocesses within this application. Since each sp
 Too add a new operation, find its relevant page in the Turf documentation. Here is [`buffer`](http://turfjs.org/static/docs/module-turf_buffer.html) for example.
 
 #### 2. Add operation info and parameters
-We need to open [`/src/js/operations/Geo.js`](https://github.com/cugos/drop-n-chop/blob/master/src/js/operations/Geo.js) and add a new object that describes the particular operation you want. Below is an example of `buffer`:
+We need to open [`/src/js/operations/Geo.js`](https://github.com/cugos/drop-n-chop/blob/master/src/js/ops.geo.dropchop.js) and add a new object that describes the particular operation you want. Below is an example of `buffer`:
 
 ```javascript
 buffer: {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "shpjs": "^3.2.1",
     "tablesort": "^3.1.0",
     "topojson": "^1.6.26",
-    "turf": "^2.0.2"
+    "turf": "^3.0.14"
   },
   "devDependencies": {
     "babelify": "^7.3.0",

--- a/src/js/dropchop.js
+++ b/src/js/dropchop.js
@@ -1,6 +1,6 @@
 var dropchop = (function(dc) {
   dc = dc || {};
-  dc.version = '0.2.1';
+  dc.version = '0.2.2';
   dc.init = function(opts) {
     if(!opts) {
       dc.util.error('No options provided in dropchop.init()');

--- a/test/spec/util.spec.js
+++ b/test/spec/util.spec.js
@@ -79,7 +79,7 @@ describe('util.dropchop.js', function() {
   it('dc.util.executeFC()', function() {
     // testing destination operation
     var expectedOutput = {"type":"FeatureCollection","features": [
-      {"type":"Feature","geometry":{"type":"Point","coordinates":[126.61573747959451, 10.098445590759695]},"properties":{"name":"Dinagat Islands"}},
+      {"type":"Feature","geometry":{"type":"Point","coordinates":[126.61573747959454, 10.098445590759694]},"properties":{"name":"Dinagat Islands"}},
       {"type":"Feature","geometry":{"type":"Point","coordinates":[131.03526863385326, 14.997661774321049]},"properties":{"name":"Some other islands"}}
     ]};
     var newFC = dc.util.executeFC(fc, 'destination', [fc, 1, 90, 'degrees']);


### PR DESCRIPTION
By some miracle, dropchop was not using any of the modules that changed name and/or params between turf v2 and v3. As such this was a simple update to address #255.

Claiming a low-hanging fruit here and moving on, because switching to modularized turf dependencies - per @mapsam's suggestion - threw a few complex errors that'll need more work in #261.